### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
         "piwik/piwik": ">=2.16.0",
         "php": ">=5.4"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8.35"
+    },
     "authors": [
         {
             "name": "Piwik",

--- a/tests/Unit/LdapClientTest.php
+++ b/tests/Unit/LdapClientTest.php
@@ -11,7 +11,7 @@ namespace Piwik\Plugins\LoginLdap\tests\Unit;
 use Piwik\ErrorHandler;
 use Piwik\Plugins\LoginLdap\Ldap\Client as LdapClient;
 use Piwik\Plugins\LoginLdap\Ldap\LdapFunctions;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 require_once PIWIK_INCLUDE_PATH . '/plugins/LoginLdap/tests/Mocks/LdapFunctions.php';
 
@@ -20,7 +20,7 @@ require_once PIWIK_INCLUDE_PATH . '/plugins/LoginLdap/tests/Mocks/LdapFunctions.
  * @group LoginLdap_Unit
  * @group LoginLdap_LdapClientTest
  */
-class LdapClientTest extends PHPUnit_Framework_TestCase
+class LdapClientTest extends TestCase
 {
     const ERROR_MESSAGE = "triggered error";
 

--- a/tests/Unit/LdapUsersTest.php
+++ b/tests/Unit/LdapUsersTest.php
@@ -13,7 +13,7 @@ use InvalidArgumentException;
 use Piwik\Plugins\LoginLdap\Ldap\ServerInfo;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserMapper;
 use Piwik\Plugins\LoginLdap\Model\LdapUsers;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 
 /**
@@ -21,7 +21,7 @@ use PHPUnit_Framework_TestCase;
  * @group LoginLdap_Unit
  * @group LoginLdap_LdapUsersTest
  */
-class LdapUsersTest extends PHPUnit_Framework_TestCase
+class LdapUsersTest extends TestCase
 {
     const TEST_USER = "rose";
     const PASSWORD = "bw";

--- a/tests/Unit/UserAccessAttributeParserTest.php
+++ b/tests/Unit/UserAccessAttributeParserTest.php
@@ -8,7 +8,7 @@
  */
 namespace Piwik\Plugins\LoginLdap\tests\Unit;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Piwik\Config;
 use Piwik\Option;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserAccessAttributeParser;
@@ -21,7 +21,7 @@ use Piwik\SettingsPiwik;
  * @group LoginLdap_Unit
  * @group LoginLdap_UserAccessAttributeParserTest
  */
-class UserAccessAttributeParserTest extends PHPUnit_Framework_TestCase
+class UserAccessAttributeParserTest extends TestCase
 {
     /**
      * @var UserAccessAttributeParser

--- a/tests/Unit/UserAccessMapperTest.php
+++ b/tests/Unit/UserAccessMapperTest.php
@@ -8,7 +8,7 @@
  */
 namespace Piwik\Plugins\LoginLdap\tests\Unit;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Piwik\Config;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserAccessAttributeParser;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserAccessMapper;
@@ -19,7 +19,7 @@ use Piwik\Plugins\SitesManager\API as SitesManagerAPI;
  * @group LoginLdap_Unit
  * @group LoginLdap_UserAccessMapperTest
  */
-class UserAccessMapperTest extends PHPUnit_Framework_TestCase
+class UserAccessMapperTest extends TestCase
 {
     /**
      * @var UserAccessMapper

--- a/tests/Unit/UserMapperTest.php
+++ b/tests/Unit/UserMapperTest.php
@@ -9,7 +9,7 @@
 namespace Piwik\Plugins\LoginLdap\tests\Unit;
 
 use Exception;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Piwik\Auth\Password;
 use Piwik\Config;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserMapper;
@@ -19,7 +19,7 @@ use Piwik\Plugins\LoginLdap\LdapInterop\UserMapper;
  * @group LoginLdap_Unit
  * @group LoginLdap_UserMapperTest
  */
-class UserMapperTest extends PHPUnit_Framework_TestCase
+class UserMapperTest extends TestCase
 {
     /**
      * @var UserMapper

--- a/tests/Unit/UserSynchronizerTest.php
+++ b/tests/Unit/UserSynchronizerTest.php
@@ -9,7 +9,7 @@
 namespace Piwik\Plugins\LoginLdap\tests\Unit;
 
 use Exception;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Piwik\Access;
 use Piwik\Auth\Password;
 use Piwik\Config;
@@ -23,7 +23,7 @@ use Piwik\Plugins\UsersManager\UserAccessFilter;
  * @group LoginLdap_Unit
  * @group LoginLdap_UserSynchronizerTest
  */
-class UserSynchronizerTest extends PHPUnit_Framework_TestCase
+class UserSynchronizerTest extends TestCase
 {
     /**
      * @var UserSynchronizer


### PR DESCRIPTION
#I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just to require PHPUnit version to [`4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this `namespace`.

refs piwik/piwik#12269