### PR TITLE
Fixes the append_user_email_suffix_to_username = 0 setting

### DIFF
--- a/LdapInterop/UserMapper.php
+++ b/LdapInterop/UserMapper.php
@@ -473,9 +473,7 @@ class UserMapper
         }
 
         $appendUserEmailSuffixToUsername = Config::shouldAppendUserEmailSuffixToUsername();
-        if (!empty($appendUserEmailSuffixToUsername)) {
-            $result->setAppendUserEmailSuffixToUsername($appendUserEmailSuffixToUsername);
-        }
+        $result->setAppendUserEmailSuffixToUsername($appendUserEmailSuffixToUsername);
 
         return $result;
     }

--- a/Model/LdapUsers.php
+++ b/Model/LdapUsers.php
@@ -604,9 +604,11 @@ class LdapUsers
 
         $result->setLdapServers(Config::getConfiguredLdapServers());
 
-        $usernameSuffix = Config::getLdapUserEmailSuffix();
-        if (!empty($usernameSuffix)) {
-            $result->setAuthenticationUsernameSuffix($usernameSuffix);
+        if (Config::shouldAppendUserEmailSuffixToUsername()) {
+            $usernameSuffix = Config::getLdapUserEmailSuffix();
+            if (!empty($usernameSuffix)) {
+                $result->setAuthenticationUsernameSuffix($usernameSuffix);
+            }
         }
 
         $requiredMemberOf = Config::getRequiredMemberOf();

--- a/tests/Integration/LdapIntegrationTest.php
+++ b/tests/Integration/LdapIntegrationTest.php
@@ -103,7 +103,7 @@ abstract class LdapIntegrationTest extends IntegrationTestCase
         return Db::fetchRow("SELECT login, password, alias, email, token_auth FROM " . Common::prefixTable('user') . " WHERE login = ?", array($login));
     }
 
-    protected function assertStarkSynchronized()
+    protected function assertStarkSynchronized($expectedDomain = 'starkindustries.com')
     {
         $user = $this->getUser(self::TEST_LOGIN);
         $this->assertNotEmpty($user);
@@ -113,11 +113,26 @@ abstract class LdapIntegrationTest extends IntegrationTestCase
         $this->assertEquals(array(
             'login' => self::TEST_LOGIN,
             'alias' => 'Tony Stark',
-            'email' => 'billionairephilanthropistplayboy@starkindustries.com',
+            'email' => 'billionairephilanthropistplayboy@' . $expectedDomain,
             'token_auth' => UsersManagerAPI::getInstance()->getTokenAuth(self::TEST_LOGIN, md5(self::TEST_PASS_LDAP))
         ), $user);
         $userMapper = new UserMapper();
         $this->assertTrue($userMapper->isUserLdapUser(self::TEST_LOGIN));
+    }
+
+    protected function assertRomanovSynchronized($expectedDomain)
+    {
+        $user = $this->getUser('blackwidow');
+        $this->assertNotEmpty($user);
+        unset($user['password']);
+        unset($user['token_auth']);
+        $this->assertEquals(array(
+            'login' => 'blackwidow',
+            'alias' => 'Natalia Romanova',
+            'email' => 'blackwidow@' . $expectedDomain,
+        ), $user);
+        $userMapper = new UserMapper();
+        $this->assertTrue($userMapper->isUserLdapUser('blackwidow'));
     }
 
     private function isLdapServerRunning()

--- a/tests/Integration/LdapUserSynchronizationTest.php
+++ b/tests/Integration/LdapUserSynchronizationTest.php
@@ -61,6 +61,16 @@ class LdapUserSynchronizationTest extends LdapIntegrationTest
         ), $access);
     }
 
+    public function test_PiwikUserIsCreated_WithEmailSuffixed_ButNotUser_IfShouldAppendEmailIsOff()
+    {
+        Config::getInstance()->LoginLdap['append_user_email_suffix_to_username'] = 0;
+        Config::getInstance()->LoginLdap['user_email_suffix'] = '@matthers.com';
+
+        $this->authenticateViaLdap('blackwidow', 'redledger');
+
+        $this->assertRomanovSynchronized('matthers.com');
+    }
+
     public function test_PiwikUserIsCreatedWithAccessToAllSites_WhenLdapLoginSucceeds_AndDefaultSitesToAddIsAll()
     {
         Config::getInstance()->LoginLdap['new_user_default_sites_view_access'] = 'all';


### PR DESCRIPTION
LdapInterop/UserMapper.php: 
The "if (!empty($appendUserEmailSuffixToUsername)) " check made it impossible to set the "append_user_email_suffix_to_username" setting to 0 

LdapInterop/UserMapper.php:
In my setup I am using "sAMAccountName" (which contains only the user name) for the "ldap_user_id_field" setting. I also need to set "user_email_suffix = @xyz.com" because my LDAP Server does not have a mail field for the users. Now this created a problem for me, because the "user_email_suffix" was always appended to the "ldap_user_id_field" value, and thus the login failed.

To fix this I added the "if (Config::shouldAppendUserEmailSuffixToUsername())" check to Model/LdapUsers.php. This may or may not be the best way to fix this issue, but in my case it solves the problem very nicely.
