### PR TITLE
Adds code to disallow createAppSpecificTokenAuth endpoint for WebServerAuth, #AS-610

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # LoginLdap Changelog
 
+#### LoginLdap 5.2.1 - 2026-07-20
+* Added code to disallow createAppSpecificTokenAuth endpoint for WebServerAuth
+
 #### LoginLdap 5.2.0 - 2026-06-22
 * Added code to enable password confirmation before any LDAP config save
 

--- a/LoginLdap.php
+++ b/LoginLdap.php
@@ -18,6 +18,7 @@ use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugin\Manager;
 use Piwik\Plugins\LoginLdap\Auth\Base as AuthBase;
+use Piwik\Plugins\LoginLdap\Auth\WebServerAuth;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserMapper;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserSynchronizer;
 use Piwik\View;
@@ -38,6 +39,7 @@ class LoginLdap extends \Piwik\Plugin
         $hooks = array(
             'Request.initAuthenticationObject'       => 'initAuthenticationObject',
             'API.Request.authenticate'               => 'apiRequestAuthenticate',
+            'API.Request.dispatch'                   => 'onApiRequestDispatch',
             'AssetManager.getJavaScriptFiles'        => 'getJsFiles',
             'AssetManager.getStylesheetFiles'        => 'getStylesheetFiles',
             'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys',
@@ -231,6 +233,31 @@ class LoginLdap extends \Piwik\Plugin
         $auth = StaticContainer::get('Piwik\Auth');
         $auth->setLogin($login = null);
         $auth->setTokenAuth($tokenAuth);
+    }
+
+    /**
+     * Listens to API.Request.dispatch.
+     *
+     * When the request is authenticated by the web server (WebServerAuth with REMOTE_USER set),
+     * WebServerAuth::authenticate() ignores the supplied password and succeeds off REMOTE_USER.
+     * UsersManager.createAppSpecificTokenAuth uses password confirmation as its ONLY
+     * authorization gate (no Access check) and accepts an arbitrary target userLogin, so under
+     * web server auth it would mint a full token_auth for any account. Block it in that context.
+     * This mirrors the dispatch guard LoginSaml installs for the same method.
+     */
+    public function onApiRequestDispatch(&$parameters, $pluginName, $methodName)
+    {
+        if ($pluginName !== 'UsersManager' || $methodName !== 'createAppSpecificTokenAuth') {
+            return;
+        }
+
+        // Only a web-server-authenticated request bypasses the password. When REMOTE_USER is
+        // absent, WebServerAuth delegates to its password-validating fallback, so token
+        // creation stays safe and must remain allowed.
+        $auth = StaticContainer::get('Piwik\Auth');
+        if ($auth instanceof WebServerAuth && !empty($_SERVER['REMOTE_USER'])) {
+            throw new Exception(Piwik::translate('LoginLdap_CreateAppSpecificTokenAuthBlocked'));
+        }
     }
 
     private function isUserLdapUser($login)

--- a/lang/en.json
+++ b/lang/en.json
@@ -93,6 +93,7 @@
         "StartTLS": "Enable TLS",
         "StartTLSFieldHelp": "To activate TLS for this server",
         "OptionsPWCONFIRMATION": "Enable password confirmation",
-        "OptionsPWCONFIRMATIONDescription": "If enabled, the requirement of a password challenge to validate admin actions will be shown and you need to enter a valid password to continue further."
+        "OptionsPWCONFIRMATIONDescription": "If enabled, the requirement of a password challenge to validate admin actions will be shown and you need to enter a valid password to continue further.",
+        "CreateAppSpecificTokenAuthBlocked": "Creating an app-specific token is not allowed when authenticating through the web server. Please contact your Matomo administrator."
     }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "LoginLdap",
-    "version": "5.2.0",
+    "version": "5.2.1",
     "description": "LDAP authentication and synchronization for Matomo.",
     "theme": false,
     "keywords": ["ldap", "login", "authentication", "active", "directory", "kerberos", "sso"],

--- a/tests/Integration/CreateAppSpecificTokenGuardTest.php
+++ b/tests/Integration/CreateAppSpecificTokenGuardTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\LoginLdap\tests\Integration;
+
+use Piwik\Container\StaticContainer;
+use Piwik\Piwik;
+use Piwik\Plugins\LoginLdap\Auth\WebServerAuth;
+use Piwik\Plugins\LoginLdap\LoginLdap;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * Regression tests for the LoginLdap privilege-escalation guard on
+ * UsersManager.createAppSpecificTokenAuth.
+ *
+ * In web-server-auth mode WebServerAuth is the global Piwik\Auth and authenticate() succeeds off
+ * $_SERVER['REMOTE_USER'] while ignoring the supplied password. Because
+ * PasswordVerifier::isPasswordCorrect() reuses that global adapter and never checks the
+ * authenticated identity against the requested login, createAppSpecificTokenAuth (whose only
+ * authorization gate is that password confirmation, with an arbitrary target userLogin) could
+ * otherwise mint a full-access token_auth for any account. The plugin blocks that method under
+ * web-server auth via its API.Request.dispatch listener; these tests pin that behaviour down.
+ *
+ * @group LoginLdap
+ * @group LoginLdap_Integration
+ */
+class CreateAppSpecificTokenGuardTest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        Fixture::loadAllTranslations();
+    }
+
+    public function tearDown(): void
+    {
+        unset($_SERVER['REMOTE_USER']);
+        Fixture::resetTranslations();
+        parent::tearDown();
+    }
+
+    public function test_blocksCreateAppSpecificTokenAuth_whenWebServerAuthenticated()
+    {
+        $this->installWebServerAuth();
+        $_SERVER['REMOTE_USER'] = 'attacker';
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage(Piwik::translate('LoginLdap_CreateAppSpecificTokenAuthBlocked'));
+
+        $parameters = ['userLogin' => 'somevictim'];
+        (new LoginLdap())->onApiRequestDispatch($parameters, 'UsersManager', 'createAppSpecificTokenAuth');
+    }
+
+    public function test_doesNotBlock_whenRemoteUserAbsent()
+    {
+        // No REMOTE_USER means WebServerAuth delegates to its password-validating fallback, so
+        // password confirmation is genuine and token creation must stay allowed.
+        $this->installWebServerAuth();
+        unset($_SERVER['REMOTE_USER']);
+
+        $parameters = ['userLogin' => 'somevictim'];
+        (new LoginLdap())->onApiRequestDispatch($parameters, 'UsersManager', 'createAppSpecificTokenAuth');
+
+        $this->assertTrue(true);
+    }
+
+    public function test_doesNotBlock_forOtherMethods()
+    {
+        $this->installWebServerAuth();
+        $_SERVER['REMOTE_USER'] = 'attacker';
+
+        $parameters = [];
+        (new LoginLdap())->onApiRequestDispatch($parameters, 'UsersManager', 'getUsers');
+
+        $this->assertTrue(true);
+    }
+
+    public function test_doesNotBlock_whenNotWebServerAuth()
+    {
+        // A password-validating adapter (the normal case) must never be blocked, even if a
+        // REMOTE_USER variable happens to be present in the environment.
+        StaticContainer::getContainer()->set('Piwik\Auth', new \Piwik\Plugins\Login\Auth());
+        $_SERVER['REMOTE_USER'] = 'attacker';
+
+        $parameters = ['userLogin' => 'somevictim'];
+        (new LoginLdap())->onApiRequestDispatch($parameters, 'UsersManager', 'createAppSpecificTokenAuth');
+
+        $this->assertTrue(true);
+    }
+
+    private function installWebServerAuth(): void
+    {
+        StaticContainer::getContainer()->set('Piwik\Auth', new WebServerAuth());
+    }
+}


### PR DESCRIPTION
## Description
Adds code to disallow createAppSpecificTokenAuth endpoint for WebServerAuth, #AS-610

## Issue No
#AS-610

## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->



## Checklist
- [✖] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [✔] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
