### PR TITLE
Adjust tests for the self-only app-specific token creation change

### DIFF
--- a/tests/Integration/AuthenticationTest.php
+++ b/tests/Integration/AuthenticationTest.php
@@ -39,12 +39,12 @@ class AuthenticationTest extends LdapIntegrationTest
         $this->addNonLdapUsers();
         Fixture::createSuperUser();
 
-        $this->nonLdapUserAppPassword = UsersManagerAPI::getInstance()->createAppSpecificTokenAuth(
+        $this->nonLdapUserAppPassword = $this->createAppSpecificTokenAuthAsAnonymous(
             self::NON_LDAP_USER,
             self::NON_LDAP_PASS,
             'test'
         );
-        $this->nonLdapNormalUserAppPassword = UsersManagerAPI::getInstance()->createAppSpecificTokenAuth(
+        $this->nonLdapNormalUserAppPassword = $this->createAppSpecificTokenAuthAsAnonymous(
             self::NON_LDAP_NORMAL_USER,
             self::NON_LDAP_NORMAL_PASS,
             'test'
@@ -171,7 +171,7 @@ class AuthenticationTest extends LdapIntegrationTest
     {
         $this->test_LdapAuth_AuthenticatesUser_WithCorrectCredentials();
 
-        $testLoginTokenAuth = UsersManagerAPI::getInstance()->createAppSpecificTokenAuth(
+        $testLoginTokenAuth = $this->createAppSpecificTokenAuthAsAnonymous(
             self::TEST_LOGIN,
             self::TEST_PASS,
             'test'

--- a/tests/Integration/LdapIntegrationTest.php
+++ b/tests/Integration/LdapIntegrationTest.php
@@ -104,6 +104,31 @@ abstract class LdapIntegrationTest extends IntegrationTestCase
         parent::tearDown();
     }
 
+    /**
+     * Creates an app specific token as an unauthenticated request (providing the user's
+     * credentials). The configured global authentication object is left untouched so it can
+     * still verify those credentials, only the current access identity is reset.
+     */
+    protected function createAppSpecificTokenAuthAsAnonymous(string $login, string $password, string $description): string
+    {
+        // Create the token as if from an unauthenticated request: only the current access
+        // identity is switched to anonymous for the call and restored afterwards. The
+        // configured global authentication object is left untouched so it can still verify
+        // the given credentials.
+        $access = Access::getInstance();
+        $loginProperty = new \ReflectionProperty(Access::class, 'login');
+        $loginProperty->setAccessible(true);
+        $previousLogin = $loginProperty->getValue($access);
+
+        $loginProperty->setValue($access, 'anonymous');
+
+        try {
+            return UsersManagerAPI::getInstance()->createAppSpecificTokenAuth($login, $password, $description);
+        } finally {
+            $loginProperty->setValue($access, $previousLogin);
+        }
+    }
+
     protected function addPreexistingSuperUser()
     {
         UsersManagerAPI::getInstance()->addUser(self::TEST_SUPERUSER_LOGIN, self::TEST_SUPERUSER_PASS, 'srodgers@aol.com');

--- a/tests/Integration/SynchronizedAuthTest.php
+++ b/tests/Integration/SynchronizedAuthTest.php
@@ -162,7 +162,7 @@ class SynchronizedAuthTest extends LdapIntegrationTest
         $userMapper = new UserMapper();
         $userMapper->markUserAsLdapUser(self::TEST_LOGIN);
 
-        $this->testUserTokenAuth = UsersManagerAPI::getInstance()->createAppSpecificTokenAuth(
+        $this->testUserTokenAuth = $this->createAppSpecificTokenAuthAsAnonymous(
             self::TEST_LOGIN,
             $pass,
             'test'
@@ -196,7 +196,7 @@ class SynchronizedAuthTest extends LdapIntegrationTest
         $auth = SynchronizedAuth::makeConfigured();
         StaticContainer::getContainer()->set(Auth::class, $auth);
 
-        $tokenAuth = $tokenAuth ?: UsersManagerAPI::getInstance()->createAppSpecificTokenAuth($login, $pass, 'test');
+        $tokenAuth = $tokenAuth ?: $this->createAppSpecificTokenAuthAsAnonymous($login, $pass, 'test');
 
         $auth->setLogin($login);
         $auth->setTokenAuth($tokenAuth);


### PR DESCRIPTION
### Summary

Companion to matomo-org/matomo#24821, which restricts `UsersManager.createAppSpecificTokenAuth` so that a logged-in user may only create an app-specific token for their own account.

Several LoginLdap tests create tokens for *other* users from a super-user context. This updates those tests to create the tokens from an unauthenticated request (providing the user's credentials), which matches the new behavior. The configured global authentication object is left untouched so it can still verify the credentials.

Affected: `AuthenticationTest`, `SynchronizedAuthTest` (via a shared `LdapIntegrationTest` helper). `WebServerAuthTest` and `SystemAuthTest` create a token for the current super user (self) and are unaffected.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
