### PR TITLE
Adds code to compare the LDAP login with the existing Matomo login before synchronizing, #AS-633

### DIFF
--- a/API.php
+++ b/API.php
@@ -146,8 +146,11 @@ class API extends \Piwik\Plugin\API
             throw new Exception(Piwik::translate('LoginLdap_UserNotFound', $login));
         }
 
-        $this->userSynchronizer->synchronizeLdapUser($login, $ldapUser);
-        $this->userSynchronizer->synchronizePiwikAccessFromLdap($login, $ldapUser);
+        $synchronizedUser = $this->userSynchronizer->synchronizeLdapUser($login, $ldapUser);
+
+        $syncedLogin = !empty($synchronizedUser['login']) ? $synchronizedUser['login'] : $login;
+
+        $this->userSynchronizer->synchronizePiwikAccessFromLdap($syncedLogin, $ldapUser);
     }
 
     /**

--- a/Auth/Base.php
+++ b/Auth/Base.php
@@ -342,7 +342,10 @@ abstract class Base implements Auth
     protected function synchronizeLdapUser($ldapUser)
     {
         $this->userForLogin = $this->userSynchronizer->synchronizeLdapUser($this->login, $ldapUser);
-        $this->userSynchronizer->synchronizePiwikAccessFromLdap($this->login, $ldapUser);
+
+        $syncedLogin = !empty($this->userForLogin['login']) ? $this->userForLogin['login'] : $this->login;
+
+        $this->userSynchronizer->synchronizePiwikAccessFromLdap($syncedLogin, $ldapUser);
     }
 
     protected function makeSuccessLogin($userInfo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### LoginLdap 5.2.3 - 2026-08-03
 * Enabled password confirmation by default on the LoginLdap settings page
-* Added code to compare the LDAP login with the existing Matomo login before synchronizing
+* Added code to synchronize LDAP users using the resolved Matomo login instead of the supplied identifier
 
 #### LoginLdap 5.2.2 - 2026-07-27
 * Added code to harden the check for anonymous user on sync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### LoginLdap 5.2.3 - 2026-08-03
 * Enabled password confirmation by default on the LoginLdap settings page
+* Added code to compare the LDAP login with the existing Matomo login before synchronizing
 
 #### LoginLdap 5.2.2 - 2026-07-27
 * Added code to harden the check for anonymous user on sync

--- a/LdapInterop/UserSynchronizer.php
+++ b/LdapInterop/UserSynchronizer.php
@@ -144,15 +144,33 @@ class UserSynchronizer
                 'ldapLogin' => $user['login']
             ));
 
+            if (!empty($existingUser) && mb_strtolower($existingUser['login']) !== mb_strtolower($user['login'])) {
+                $logger->warning(
+                    "UserSynchronizer::{func}: refusing to synchronize LDAP user '{ldapLogin}': it resolves to the "
+                        . "existing Matomo user '{existingLogin}', which is a different login. This usually means two "
+                        . "LDAP identities differing by accent map onto one Matomo login.",
+                    array(
+                        'func' => 'synchronizeLdapUser',
+                        'ldapLogin' => $user['login'],
+                        'existingLogin' => $existingUser['login'],
+                    )
+                );
+
+                throw new \Exception("Cannot synchronize LDAP user '{$user['login']}': it resolves to a different "
+                    . "existing Matomo login.");
+            }
+
+            $syncLogin = !empty($existingUser) ? $existingUser['login'] : $user['login'];
+
             if (empty($existingUser)) {
                 //Need to set this to ensure we can add a new user without any password confirmation, refer skipPasswordConfirmation() in LoginLdap.php for further usage
                 self::$skipPasswordConfirmation = true;
-                $usersManagerApi->addUser($user['login'], $user['password'], $user['email'], $isPasswordHashed = true);
+                $usersManagerApi->addUser($syncLogin, $user['password'], $user['email'], $isPasswordHashed = true);
                 self::$skipPasswordConfirmation = false;
 
                 // set new user view access
                 if (!empty($newUserDefaultSitesWithViewAccess)) {
-                    $usersManagerApi->setUserAccess($user['login'], 'view', $newUserDefaultSitesWithViewAccess);
+                    $usersManagerApi->setUserAccess($syncLogin, 'view', $newUserDefaultSitesWithViewAccess);
                 }
             } else {
                 if (!$userMapper->isUserLdapUser($existingUser['login'])) {
@@ -161,27 +179,27 @@ class UserSynchronizer
                     if (Config::getShouldSynchronizeUsersAfterLogin()) {
                         $usersManagerApi::$UPDATE_USER_REQUIRE_PASSWORD_CONFIRMATION = false;
                         self::$allowUpdateUser = true;
-                        $usersManagerApi->updateUser($user['login'], $user['password'], $user['email'], $isPasswordHashed = true, true);
+                        $usersManagerApi->updateUser($syncLogin, $user['password'], $user['email'], $isPasswordHashed = true, true);
                         $usersManagerApi::$UPDATE_USER_REQUIRE_PASSWORD_CONFIRMATION = true;
                         self::$allowUpdateUser = false;
                     } else {
                         self::$allowUpdateUser = true;
-                        $userUpdater->updateUserWithoutCurrentPassword($user['login'], $user['password'], $user['email'], $isPasswordHashed = true);
+                        $userUpdater->updateUserWithoutCurrentPassword($syncLogin, $user['password'], $user['email'], $isPasswordHashed = true);
                         self::$allowUpdateUser = false;
                     }
 
                     // manually reset ts_password_modified to user creation date since it will just cause sessions to prematurely expire
                     // (note: it is not possible to change LDAP passwords through Matomo)
-                    $this->resetUserTsPassword($user['login']);
+                    $this->resetUserTsPassword($syncLogin);
                 }
             }
 
-            $userMapper->markUserAsLdapUser($user['login']);
+            $userMapper->markUserAsLdapUser($syncLogin);
             if (!empty($existingUser['invite_token'])) {
-                $this->autoAcceptInvite($user['login']);
+                $this->autoAcceptInvite($syncLogin);
             }
 
-            return $userModel->getUser($user['login']);
+            return $userModel->getUser($syncLogin);
         });
     }
 

--- a/tests/Unit/UserSynchronizerTest.php
+++ b/tests/Unit/UserSynchronizerTest.php
@@ -112,6 +112,18 @@ class UserSynchronizerTest extends TestCase
         $this->userSynchronizer->synchronizeLdapUser('piwikuser', array());
     }
 
+    public function test_synchronizeLdapUser_Throws_IfLdapUserResolvesToDifferentExistingMatomoLogin()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Cannot synchronize LDAP user 'josé': it resolves to a different existing Matomo login.");
+
+        $this->setUserManagerApiMock($throws = false);
+        $this->setUserModelMock(array('login' => 'jose', 'password' => 'password', 'email' => 'email'));
+        $this->setUserMapperMock(array('login' => 'josé', 'password' => 'password', 'email' => 'email'));
+
+        $this->userSynchronizer->synchronizeLdapUser('josé', array());
+    }
+
     public function test_synchronizeLdapUser_Succeeds_IfUserDoesNotExistInDb()
     {
         $this->setUserManagerApiMock($throws = false);


### PR DESCRIPTION
## Description
Adds code to compare the LDAP login with the existing Matomo login before synchronizing

## Issue No
#AS-633

## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✖] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
