### PR TITLE
Drop registration of removed core variables.less

### DIFF
--- a/LoginLdap.php
+++ b/LoginLdap.php
@@ -64,7 +64,6 @@ class LoginLdap extends \Piwik\Plugin
     public function getStylesheetFiles(&$stylesheetFiles)
     {
         $stylesheetFiles[] = "plugins/Login/stylesheets/login.less";
-        $stylesheetFiles[] = "plugins/Login/stylesheets/variables.less";
         $stylesheetFiles[] = "plugins/LoginLdap/vue/src/Admin/Admin.less";
         $stylesheetFiles[] = "plugins/LoginLdap/vue/src/TestableField/TestableField.less";
     }


### PR DESCRIPTION
## Description

Core PR "Prune dead and deprecated LESS variables" deletes `plugins/Login/stylesheets/variables.less`. This plugin registers that file in `getStylesheetFiles()`, and registering a file that no longer exists makes stylesheet merging throw `The ui asset with 'href' = ... is not readable`, which breaks every view- and email-rendering test of the plugin. Nothing here used `@login-section-background`, so the line can simply go.

This update should follow the merge of this PR:

- https://github.com/matomo-org/matomo/pull/24925

issue dev-20576

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
