### PR TITLE
Register the What's New stylesheet and login form validation translations

### DIFF
--- a/LoginLdap.php
+++ b/LoginLdap.php
@@ -66,6 +66,7 @@ class LoginLdap extends \Piwik\Plugin
         $stylesheetFiles[] = "plugins/Login/stylesheets/login.less";
         $stylesheetFiles[] = "plugins/Login/stylesheets/loginLayout.less";
         $stylesheetFiles[] = "plugins/Login/stylesheets/loginForm.less";
+        $stylesheetFiles[] = "plugins/Login/stylesheets/loginWhatsNew.less";
         $stylesheetFiles[] = "plugins/LoginLdap/vue/src/Admin/Admin.less";
         $stylesheetFiles[] = "plugins/LoginLdap/vue/src/TestableField/TestableField.less";
     }
@@ -152,6 +153,11 @@ class LoginLdap extends \Piwik\Plugin
         $keys[] = 'LoginLdap_OptionsPWCONFIRMATIONDescription';
         $keys[] = 'General_Warning';
         $keys[] = 'LoginLdap_LoginPluginEnabledWarning';
+
+        // Used by the login form validation in Login's login.js, which is registered above.
+        $keys[] = 'Login_LoginOrEmail';
+        $keys[] = 'General_Password';
+        $keys[] = 'General_Required';
     }
 
     /**


### PR DESCRIPTION
### What

Registers `plugins/Login/stylesheets/loginWhatsNew.less` and the three translation keys used by Login's `login.js`.

### Why

LoginLdap registers Login's assets itself, because the Login plugin may be deactivated. It had fallen behind what core registers:

- Core's `Login::getStylesheetFiles()` lists four stylesheets, LoginLdap listed three. Without `loginWhatsNew.less` the What's New panel on the login page renders with no card, no borders and default type.
- Core's `login.js`, which LoginLdap registers in `getJsFiles()`, uses `Login_LoginOrEmail`, `General_Password` and `General_Required`. Without them the field validation shows raw key names.

Only affects installs that have deactivated the Login plugin.

<img width="200" height="300" alt="image" src="https://github.com/user-attachments/assets/d4d4c307-5bcd-4318-a60e-75c769cbaf78" />
<img width="200" height="300" alt="image" src="https://github.com/user-attachments/assets/588895bd-f026-47b5-a6e4-4b34c426cd59" />


Follow-up to #462. The 5.x equivalent is in #469, where the stylesheets need an existence check because Matomo 5.0-5.13 don't ship them; every 6.x ships all four, so no check is needed here.

### Review

Set `[Plugins] Plugins[] = LoginLdap` with `Login` deactivated, open the login page, and check the What's New panel is styled and submitting an empty form shows translated errors.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
