### PR TITLE
Release the login redesign support as 5.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # LoginLdap Changelog
 
+#### LoginLdap 5.2.5 - 2026-08-17
+- Added the stylesheets of the refreshed Matomo login layout, so the LDAP login page matches it
+- Added code to fix the missing translations in the login form validation messages
+
 #### LoginLdap 5.2.4 - 2026-08-10
 - Added code to change the logic for random password generation
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "LoginLdap",
-    "version": "5.2.4",
+    "version": "5.2.5",
     "description": "LDAP authentication and synchronization for Matomo.",
     "theme": false,
     "keywords": ["ldap", "login", "authentication", "active", "directory", "kerberos", "sso"],


### PR DESCRIPTION
## Description

LoginLdap was updated for Matomo's refreshed login layout (#469): it registers the new Login stylesheets, and adds the translation keys the login form's validation messages need. Without a release, sites using LoginLdap keep an unstyled login page and untranslated validation messages on the new layout.

The change merged after 5.2.4 was tagged, so this adds the 5.2.5 changelog entry and bumps `plugin.json`. No code changes.

## Issue No

Related to #469

## Steps to Replicate the Issue

1. Compare the 5.2.4 tag against `5.x-dev`.
2. Expected: the login layout support carries a version users can install.
3. Actual: it sits on `5.x-dev` with `plugin.json` still at 5.2.4 and no changelog entry.

## Checklist
- [✖] Tested locally or on demo2/demo3? (changelog and version metadata only, no code change)
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
