### PR TITLE
Start TLS before binding on the Matomo 6 line, AS-687

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### LoginLdap 6.0.0
 * Compatibility with Matomo 6
+* Added strict check for TLS if enabled
 
 #### LoginLdap 5.2.4 - 2026-08-10
 - Added code to change the logic for random password generation

--- a/Ldap/Client.php
+++ b/Ldap/Client.php
@@ -73,8 +73,10 @@ class Client
      * @param string $serverHostName The hostname of the LDAP server.
      * @param int $port The server port to use.
      * @param int $timeout The timeout in seconds of the network connection.
-     * @throws Exception If an error occurs during the `ldap_connect` call or if there is a connection
-     *                   issue during the subsequent anonymous bind.
+     * @param bool $startTLS Whether to upgrade the connection using StartTLS before using it.
+     * @throws Exception If an error occurs during the `ldap_connect` call, if StartTLS was requested
+     *                   but could not be started, or if there is a connection issue during the
+     *                   subsequent anonymous bind.
      */
     public function connect($serverHostName, $port = ServerInfo::DEFAULT_LDAP_PORT, $timeout = self::DEFAULT_TIMEOUT_SECS, $startTLS = false)
     {
@@ -98,24 +100,34 @@ class Client
 
         $this->logger->debug("ldap_connect result is {result}", array('result' => $this->connectionResource));
 
+        // if TLS was requested, the connection has to be upgraded before anything else is sent over it.
+        // a failure here is always fatal: carrying on would send the LDAP credentials over an
+        // unencrypted connection, which is exactly what enabling TLS is supposed to prevent.
+        if ($startTLS) {
+            if (!ldap_start_tls($this->connectionResource)) {
+                $error = ldap_error($this->connectionResource);
+
+                $this->logger->debug("ldap_start_tls failed: {err}", array('err' => $error));
+
+                $this->closeIfCurrentlyOpen();
+
+                throw new Exception("ldap_start_tls failed: " . $error);
+            }
+
+            $this->logger->debug("ldap_start_tls call finished; TLS is started");
+        }
+
         // ldap_connect will not always try to connect to the server, so execute a bind
         // to test the connection
         try {
-            if ($startTLS) {
-                if (!ldap_start_tls($this->connectionResource)) {
-                    throw new Exception("ldap_start_tls failed: " . ldap_error($this->connectionResource));
-                }
-            }
             ldap_bind($this->connectionResource);
 
-            $this->logger->debug("anonymous ldap_bind call finished; connection ok" . ($startTLS ? ' + TLS is started' : ''));
+            $this->logger->debug("anonymous ldap_bind call finished; connection ok");
         } catch (Exception $ex) {
             // if the error was due to a connection error, rethrow, otherwise ignore it
             $errno = ldap_errno($this->connectionResource);
 
-            $fct = ($startTLS ? "ldap_start_tls" : "ldap_bind");
-
-            $this->logger->debug("anonymous {fct} returned error '{err}'", array('err' => $errno, 'fct' => $fct));
+            $this->logger->debug("anonymous ldap_bind returned error '{err}'", array('err' => $errno));
 
             if (!in_array($errno, self::$initialBindErrorCodesToIgnore)) {
                 throw $ex;

--- a/tests/Mocks/LdapFunctions.php
+++ b/tests/Mocks/LdapFunctions.php
@@ -48,6 +48,18 @@ function ldap_error($link_identifier)
     return LdapFunctions::ldap_error($link_identifier);
 }
 
+function ldap_start_tls($connection = null)
+{
+    /** @noinspection PhpUndefinedMethodInspection */
+    return LdapFunctions::ldap_start_tls($connection);
+}
+
+function ldap_errno($link_identifier)
+{
+    /** @noinspection PhpUndefinedMethodInspection */
+    return LdapFunctions::ldap_errno($link_identifier);
+}
+
 function ldap_bind($connection = null, $resourceDn = null, $password = null)
 {
     /** @noinspection PhpUndefinedMethodInspection */

--- a/tests/Unit/LdapClientTest.php
+++ b/tests/Unit/LdapClientTest.php
@@ -33,7 +33,8 @@ class LdapClientTest extends TestCase
         LdapFunctions::$phpUnitMock = $this->getMockBuilder('stdClass')
                                            ->addMethods(array('ldap_connect', 'ldap_close',
                                              'ldap_bind', 'ldap_search', 'ldap_set_option',
-                                             'ldap_get_entries', 'ldap_count_entries', 'ldap_error'))
+                                             'ldap_get_entries', 'ldap_count_entries', 'ldap_error',
+                                             'ldap_start_tls', 'ldap_errno'))
                                            ->getMock();
     }
 
@@ -90,6 +91,81 @@ class LdapClientTest extends TestCase
 
         $ldapClient = new LdapClient();
         $ldapClient->connect("hostname", 1234);
+    }
+
+    public function getStartTlsFailureErrorCodes()
+    {
+        return array(
+            // codes that are ignored for the anonymous bind, but must never be ignored for StartTLS
+            array(7), // LDAP_AUTH_METHOD_NOT_SUPPORTED
+            array(8), // LDAP_STRONG_AUTH_REQUIRED
+            array(48), // LDAP_INAPPROPRIATE_AUTH
+            array(49), // LDAP_INVALID_CREDENTIALS
+            array(50), // LDAP_INSUFFICIENT_ACCESS
+
+            array(2), // LDAP_PROTOCOL_ERROR
+            array(52), // LDAP_UNAVAILABLE
+        );
+    }
+
+    /**
+     * @dataProvider getStartTlsFailureErrorCodes
+     */
+    public function test_connect_Throws_AndDoesNotUseTheConnection_IfStartTLSFails($errorCode)
+    {
+        $this->addLdapConnectMethodMock("hostname", 1234);
+
+        LdapFunctions::$phpUnitMock->expects($this->once())->method('ldap_start_tls')->will($this->returnValue(false));
+        LdapFunctions::$phpUnitMock->expects($this->any())->method('ldap_error')
+            ->will($this->returnValue("start tls error"));
+        LdapFunctions::$phpUnitMock->expects($this->any())->method('ldap_errno')->will($this->returnValue($errorCode));
+
+        // nothing may be sent over a connection that failed to upgrade to TLS
+        LdapFunctions::$phpUnitMock->expects($this->never())->method('ldap_bind');
+        LdapFunctions::$phpUnitMock->expects($this->never())->method('ldap_search');
+        LdapFunctions::$phpUnitMock->expects($this->once())->method('ldap_close');
+
+        $ldapClient = new LdapClient();
+
+        $exception = null;
+        try {
+            $ldapClient->connect("hostname", 1234, LdapClient::DEFAULT_TIMEOUT_SECS, true);
+        } catch (\Exception $ex) {
+            $exception = $ex;
+        }
+
+        $this->assertNotNull(
+            $exception,
+            "connect() did not throw although ldap_start_tls failed with error code $errorCode"
+        );
+        $this->assertStringStartsWith("ldap_start_tls failed:", $exception->getMessage());
+        $this->assertFalse($ldapClient->isOpen());
+    }
+
+    public function test_connect_BindsAnonymously_IfStartTLSSucceeds()
+    {
+        $this->addLdapConnectMethodMock("hostname", 1234);
+
+        LdapFunctions::$phpUnitMock->expects($this->once())->method('ldap_start_tls')
+            ->with($this->equalTo("connection_resource_hostname_1234"))->will($this->returnValue(true));
+        LdapFunctions::$phpUnitMock->expects($this->once())->method('ldap_bind');
+
+        $ldapClient = new LdapClient();
+        $ldapClient->connect("hostname", 1234, LdapClient::DEFAULT_TIMEOUT_SECS, true);
+
+        $this->assertTrue($ldapClient->isOpen());
+    }
+
+    public function test_connect_DoesNotStartTLS_IfNotRequested()
+    {
+        $this->addLdapConnectMethodMock("hostname", 1234);
+
+        LdapFunctions::$phpUnitMock->expects($this->never())->method('ldap_start_tls');
+
+        $ldapClient = new LdapClient();
+        $ldapClient->connect("hostname", 1234);
+
+        $this->assertTrue($ldapClient->isOpen());
     }
 
     public function test_close_Succeeds_IfConnectionAlreadyClosed()


### PR DESCRIPTION
## Description

Forward-port of AS-687 from `5.x-dev` (matomo-org/plugin-LoginLdap#474, commit 6c526a3) to the Matomo 6 line, cherry-picked so the original authorship is kept.

When StartTLS is enabled, the connection has to be upgraded before anything is sent over it. On `6.x-dev` the `ldap_start_tls()` call still sits inside the connection-test block after the bind is set up, and a failure to start TLS is not treated as fatal — so a failed upgrade could leave the LDAP bind credentials going over an unencrypted connection, which is the one thing enabling TLS is meant to prevent. This moves the upgrade ahead of the bind, closes the connection and throws if it fails, and logs the outcome either way.

Without this, Matomo 6 would ship LoginLdap with a credential-exposure path that is already fixed on the Matomo 5 line.

Only the version and changelog conflicted: the plugin version stays at `6.0.0` and the bullet is folded into the existing unreleased 6.0.0 entry rather than adding a 5.2.6 section to this line.

## Issue No

AS-687. Forward-port of #474.

## Steps to Replicate the Issue
1. Configure LoginLdap against an LDAP server with StartTLS enabled, and make the TLS upgrade fail (for example by pointing at a server whose certificate cannot be verified).
2. Expected: the connection is closed and an error is raised before any credentials are sent.
3. Actual on 6.x-dev: the upgrade failure is not fatal and the bind still proceeds over the unencrypted connection.

## Checklist
- [✖] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✖] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
