### PR TITLE
Hardens login comparison and web server auth session

### DIFF
--- a/Auth/Base.php
+++ b/Auth/Base.php
@@ -17,6 +17,7 @@ use Piwik\Piwik;
 use Piwik\Plugins\LoginLdap\Config;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserSynchronizer;
 use Piwik\Plugins\LoginLdap\Model\LdapUsers;
+use Piwik\Plugins\LoginLdap\UserIdentity;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 use Piwik\Plugins\UsersManager\Model as UserModel;
 use Piwik\Log\LoggerInterface;
@@ -306,9 +307,19 @@ abstract class Base implements Auth
         return $this->userForLogin;
     }
 
-    private function isSameLogin(string $assertedLogin, string $storedLogin): bool
+    /**
+     * Returns whether the asserted login and the login of the user row it resolved to identify the same user.
+     *
+     * Implementations that verify no credential against the returned row have to override this and require an
+     * exact match.
+     *
+     * @param string $assertedLogin
+     * @param string $storedLogin
+     * @return bool
+     */
+    protected function isSameLogin(string $assertedLogin, string $storedLogin): bool
     {
-        return mb_strtolower($assertedLogin, 'UTF-8') === mb_strtolower($storedLogin, 'UTF-8');
+        return UserIdentity::isSameLogin($assertedLogin, $storedLogin);
     }
 
     protected function tryFallbackAuth($onlySuperUsers = true, ?Auth $auth = null)

--- a/Auth/WebServerAuth.php
+++ b/Auth/WebServerAuth.php
@@ -17,6 +17,7 @@ use Piwik\Plugins\LoginLdap\Config;
 use Piwik\Plugins\LoginLdap\Ldap\Exceptions\ConnectionException;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserSynchronizer;
 use Piwik\Plugins\LoginLdap\Model\LdapUsers;
+use Piwik\Plugins\LoginLdap\UserIdentity;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 use Piwik\Plugins\UsersManager\Model as UserModel;
 use Piwik\Session;
@@ -63,21 +64,21 @@ class WebServerAuth extends Base
     public function authenticate()
     {
         try {
-            $webServerAuthUser = $this->getAlreadyAuthenticatedLogin();
+            $webServerAuthUser = self::getAlreadyAuthenticatedLogin();
 
             if (empty($webServerAuthUser)) {
                 $this->logger->debug("using web server authentication, but REMOTE_USER server variable not found.");
 
                 return $this->tryFallbackAuth($onlySuperUsers = false, $this->fallbackAuth);
             } else {
-                if (Config::getStripDomainFromWebAuth()) {
-                    $this->login = preg_replace('/(.*?\\\\)|(@.*)/', '', $webServerAuthUser);
-                } else {
-                    $this->login = $webServerAuthUser;
-                }
+                $this->login = self::getAssertedLogin();
                 $this->password = '';
 
                 $this->logger->info("User '{login}' authenticated by webserver.", array('login' => $this->login));
+
+                // resolve the login before synchronizing, so that a login resolving to a different existing
+                // user is rejected before synchronization writes to that user's row
+                $this->getUserForLogin();
 
                 if ($this->synchronizeUsersAfterSuccessfulLogin) {
                     $this->synchronizeLoggedInUser();
@@ -146,15 +147,49 @@ class WebServerAuth extends Base
         $this->fallbackAuth = $fallbackAuth;
     }
 
-    private function getAlreadyAuthenticatedLogin()
+    private static function getAlreadyAuthenticatedLogin()
     {
         return @$_SERVER['REMOTE_USER'];
+    }
+
+    /**
+     * Returns the login the web server authenticated for this request, normalized the way
+     * {@link self::authenticate()} normalizes it, or null when the web server authenticated nobody.
+     *
+     * @return string|null
+     */
+    public static function getAssertedLogin(): ?string
+    {
+        $webServerAuthUser = self::getAlreadyAuthenticatedLogin();
+
+        if (empty($webServerAuthUser)) {
+            return null;
+        }
+
+        if (Config::getStripDomainFromWebAuth()) {
+            return preg_replace('/(.*?\\\\)|(@.*)/', '', $webServerAuthUser);
+        }
+
+        return $webServerAuthUser;
     }
 
     public static function isCurrentRequestWebServerAuthenticated(): bool
     {
         $auth = StaticContainer::get('Piwik\Auth');
         return $auth instanceof WebServerAuth && !empty($_SERVER['REMOTE_USER']);
+    }
+
+    /**
+     * No password, password hash or token auth is verified against the row the asserted login resolves to, so
+     * unlike the other auth implementations this one requires the stored login to match it exactly.
+     *
+     * @param string $assertedLogin
+     * @param string $storedLogin
+     * @return bool
+     */
+    protected function isSameLogin(string $assertedLogin, string $storedLogin): bool
+    {
+        return UserIdentity::isSameLoginExact($assertedLogin, $storedLogin);
     }
 
     private function synchronizeLoggedInUser()

--- a/Auth/WebServerSessionAuth.php
+++ b/Auth/WebServerSessionAuth.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\LoginLdap\Auth;
+
+use Piwik\AuthResult;
+use Piwik\Container\StaticContainer;
+use Piwik\Log\LoggerInterface;
+use Piwik\Plugins\LoginLdap\Config;
+use Piwik\Plugins\LoginLdap\UserIdentity;
+use Piwik\Session;
+use Piwik\Session\SessionAuth;
+use Piwik\Session\SessionFingerprint;
+
+/**
+ * Decorates the core session authentication so that a Matomo session cannot outlive the web server identity
+ * it was created for.
+ *
+ * FrontController authenticates from the session before it consults `Piwik\Auth`, and skips the configured
+ * auth implementation when that succeeds, so {@link WebServerAuth} is not consulted again while a session
+ * exists. Ending the session on a mismatch makes FrontController fall through to WebServerAuth, which then
+ * logs the newly asserted user in.
+ */
+class WebServerSessionAuth extends SessionAuth
+{
+    /**
+     * @var SessionAuth
+     */
+    private $wrapped;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param SessionAuth $wrapped
+     * @param LoggerInterface|null $logger
+     * @param bool $shouldDestroySession For tests, since there is no actual session there.
+     */
+    public function __construct(SessionAuth $wrapped, ?LoggerInterface $logger = null, $shouldDestroySession = true)
+    {
+        parent::__construct(null, $shouldDestroySession);
+
+        $this->wrapped = $wrapped;
+        $this->logger = $logger ?: StaticContainer::get(LoggerInterface::class);
+    }
+
+    public function authenticate()
+    {
+        $sessionUser = $this->getSessionUserToEndFor();
+
+        if ($sessionUser === null) {
+            return $this->wrapped->authenticate();
+        }
+
+        $this->logger->info(
+            "WebServerSessionAuth::{func}: ending the session of '{sessionUser}', the web server now "
+                . "authenticates '{assertedUser}'.",
+            array(
+                'func' => __FUNCTION__,
+                'sessionUser' => $sessionUser,
+                'assertedUser' => WebServerAuth::getAssertedLogin(),
+            )
+        );
+
+        $this->endSession();
+
+        return new AuthResult(AuthResult::FAILURE, null, null);
+    }
+
+    /**
+     * Returns the session's user when the web server now authenticates somebody else, null otherwise.
+     *
+     * The wrapped session auth is deliberately not run first, so that on a mismatch nothing of the previous
+     * user is left on this instance for FrontController to read back.
+     *
+     * @return string|null
+     */
+    private function getSessionUserToEndFor(): ?string
+    {
+        if (!Config::shouldUseWebServerAuthentication()) {
+            return null;
+        }
+
+        $assertedLogin = WebServerAuth::getAssertedLogin();
+
+        // an absent REMOTE_USER is not a mismatch: setups that require web server authentication on only some
+        // paths would otherwise log people out at random
+        if ($assertedLogin === null) {
+            return null;
+        }
+
+        $sessionUser = (new SessionFingerprint())->getUser();
+
+        if (empty($sessionUser) || UserIdentity::isSameLoginExact($assertedLogin, $sessionUser)) {
+            return null;
+        }
+
+        return $sessionUser;
+    }
+
+    /**
+     * Empties the session before regenerating it.
+     *
+     * `destroyCurrentSession()` only clears the session fingerprint, and regenerating the id copies the
+     * remaining session data across, which would hand the previous user's namespaces to the new one.
+     */
+    private function endSession(): void
+    {
+        if (Session::isSessionStarted()) {
+            $_SESSION = array();
+        }
+
+        $this->destroyCurrentSession(new SessionFingerprint());
+    }
+
+    public function getName()
+    {
+        return $this->wrapped->getName();
+    }
+
+    public function setTokenAuth(
+        #[\SensitiveParameter]
+        $token_auth
+    ) {
+        $this->wrapped->setTokenAuth($token_auth);
+    }
+
+    public function getLogin()
+    {
+        return $this->wrapped->getLogin();
+    }
+
+    public function getTokenAuth()
+    {
+        return $this->wrapped->getTokenAuth();
+    }
+
+    public function getTokenAuthSecret()
+    {
+        return $this->wrapped->getTokenAuthSecret();
+    }
+
+    public function setLogin($login)
+    {
+        $this->wrapped->setLogin($login);
+    }
+
+    public function setPassword(
+        #[\SensitiveParameter]
+        $password
+    ) {
+        $this->wrapped->setPassword($password);
+    }
+
+    public function setPasswordHash(
+        #[\SensitiveParameter]
+        $passwordHash
+    ) {
+        $this->wrapped->setPasswordHash($passwordHash);
+    }
+
+    public function wasSessionExpired(): bool
+    {
+        return $this->wrapped->wasSessionExpired();
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # LoginLdap Changelog
 
+#### LoginLdap 5.2.7
+- Fixed the login comparison so that logins the database collation treats as equal, but which are different users, are no longer accepted
+- Added an exact login match requirement when authenticating through the web server
+- Added termination of a Matomo session when the web server starts authenticating a different user
+
 #### LoginLdap 5.2.6 - 2026-08-24
 - Added strict check for TLS if enabled
 - Added strict comparison of login username

--- a/LdapInterop/UserSynchronizer.php
+++ b/LdapInterop/UserSynchronizer.php
@@ -17,6 +17,7 @@ use Piwik\Date;
 use Piwik\Db;
 use Piwik\Piwik;
 use Piwik\Plugins\LoginLdap\Config;
+use Piwik\Plugins\LoginLdap\UserIdentity;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 use Piwik\Plugins\UsersManager\Model as UserModel;
 use Piwik\Plugins\UsersManager\UserUpdater;
@@ -145,11 +146,10 @@ class UserSynchronizer
                 'ldapLogin' => $user['login']
             ));
 
-            if (!empty($existingUser) && mb_strtolower($existingUser['login']) !== mb_strtolower($user['login'])) {
+            if (!empty($existingUser) && !UserIdentity::isSameLogin($user['login'], $existingUser['login'])) {
                 $logger->warning(
                     "UserSynchronizer::{func}: refusing to synchronize LDAP user '{ldapLogin}': it resolves to the "
-                        . "existing Matomo user '{existingLogin}', which is a different login. This usually means two "
-                        . "LDAP identities differing by accent map onto one Matomo login.",
+                        . "existing Matomo user '{existingLogin}', which is a different login.",
                     array(
                         'func' => 'synchronizeLdapUser',
                         'ldapLogin' => $user['login'],

--- a/UserIdentity.php
+++ b/UserIdentity.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\LoginLdap;
+
+/**
+ * Compares an asserted login with the login of the Matomo user it resolved to.
+ *
+ * Users are looked up through the collation of the `login` column, so a lookup can return a row whose login
+ * only collates the same as the asserted one. These comparisons decide whether such a row may be used.
+ */
+class UserIdentity
+{
+    /**
+     * Returns true if the asserted login and the stored login identify the same Matomo user.
+     *
+     * Only ASCII case differences are tolerated, since LDAP directories match user ids case insensitively.
+     * Unicode aware folding must not be used here, as it treats as equal the same values the collation does.
+     *
+     * @param string $assertedLogin The login the authentication attempt was made with.
+     * @param string $storedLogin The login of the user row the lookup returned.
+     * @return bool
+     */
+    public static function isSameLogin(string $assertedLogin, string $storedLogin): bool
+    {
+        return self::asciiLower($assertedLogin) === self::asciiLower($storedLogin);
+    }
+
+    /**
+     * Returns true if the asserted login and the stored login are byte for byte identical.
+     *
+     * Used where the login is the only thing binding a request to an account, so that not even ASCII case
+     * differences are tolerated.
+     *
+     * @param string $assertedLogin The login the web server asserted.
+     * @param string $storedLogin The login of the user row, or of the session, it was matched against.
+     * @return bool
+     */
+    public static function isSameLoginExact(string $assertedLogin, string $storedLogin): bool
+    {
+        return $assertedLogin === $storedLogin;
+    }
+
+    /**
+     * Lowercases the ASCII letters in $value and leaves every other byte untouched.
+     *
+     * strtolower() is not used since it is locale aware on PHP versions before 8.2 and can fold bytes outside
+     * of ASCII.
+     *
+     * @param string $value
+     * @return string
+     */
+    private static function asciiLower(string $value): string
+    {
+        return strtr($value, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+    }
+}

--- a/config/config.php
+++ b/config/config.php
@@ -8,6 +8,11 @@
  */
 
 return [
+    // keeps a Matomo session from outliving the web server identity it was created for
+    \Piwik\Session\SessionAuth::class => \Piwik\DI::decorate(function (\Piwik\Session\SessionAuth $previous) {
+        return new \Piwik\Plugins\LoginLdap\Auth\WebServerSessionAuth($previous);
+    }),
+
     'observers.global' => \Piwik\DI::add([
         ['Login.userRequiresPasswordConfirmation', \Piwik\DI::value(function (&$requiresPasswordConfirmation, $login) {
             if (\Piwik\Plugins\LoginLdap\Auth\WebServerAuth::isCurrentRequestWebServerAuthenticated()) {

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "LoginLdap",
-    "version": "5.2.6",
+    "version": "5.2.7",
     "description": "LDAP authentication and synchronization for Matomo.",
     "theme": false,
     "keywords": ["ldap", "login", "authentication", "active", "directory", "kerberos", "sso"],

--- a/tests/Integration/WebServerAuthTest.php
+++ b/tests/Integration/WebServerAuthTest.php
@@ -70,6 +70,32 @@ class WebServerAuthTest extends LdapIntegrationTest
         $this->assertEquals(0, $authResult->getCode());
     }
 
+    /**
+     * @dataProvider getLoginsResolvingToTheSuperUser
+     */
+    public function test_WebServerAuth_Fails_IfAssertedLoginResolvesToDifferentExistingUser($remoteUser)
+    {
+        Config::getInstance()->LoginLdap['use_webserver_auth'] = 1;
+
+        // each of these resolves to the existing super user through the collation of the login column, but the
+        // web server authenticated a different principal
+        $_SERVER['REMOTE_USER'] = $remoteUser;
+
+        $ldapAuth = WebServerAuth::makeConfigured();
+        $authResult = $ldapAuth->authenticate();
+
+        $this->assertEquals(AuthResult::FAILURE, $authResult->getCode());
+        $this->assertNotEquals(self::TEST_SUPERUSER_LOGIN, $authResult->getIdentity());
+    }
+
+    public function getLoginsResolvingToTheSuperUser()
+    {
+        return array(
+            'ascii case difference' => array(ucfirst(self::TEST_SUPERUSER_LOGIN)),
+            'accented character' => array(substr(self::TEST_SUPERUSER_LOGIN, 0, -1) . "\xc3\xa1"),
+        );
+    }
+
     public function test_WebServerAuth_Fails_IfUserIsNotPartOfRequiredGroup()
     {
         Config::getInstance()->LoginLdap['use_webserver_auth'] = 1;

--- a/tests/Unit/UserIdentityTest.php
+++ b/tests/Unit/UserIdentityTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\LoginLdap\tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\Plugins\LoginLdap\UserIdentity;
+
+/**
+ * @group LoginLdap
+ * @group LoginLdap_Unit
+ * @group LoginLdap_UserIdentityTest
+ */
+class UserIdentityTest extends TestCase
+{
+    /**
+     * @dataProvider getLoginsToCompare
+     */
+    public function test_isSameLogin_ComparesLoginsWithoutUnicodeFolding($expected, $assertedLogin, $storedLogin)
+    {
+        $this->assertSame($expected, UserIdentity::isSameLogin($assertedLogin, $storedLogin));
+    }
+
+    public function getLoginsToCompare()
+    {
+        return array(
+            'identical' => array(true, 'karen', 'karen'),
+            'ascii case difference' => array(true, 'Karen', 'karen'),
+            'ascii case difference, other way round' => array(true, 'karen', 'KAREN'),
+            'different logins' => array(false, 'karen', 'bob'),
+
+            // the collation of the login column equates these pairs, as does mb_strtolower()
+            'kelvin sign' => array(false, "\xe2\x84\xaaaren", 'Karen'),
+            'angstrom sign' => array(false, "\xe2\x84\xabngus", 'Ångus'),
+            'accent' => array(false, 'josé', 'jose'),
+            'sharp s' => array(false, 'straße', 'strasse'),
+            'trailing space, PAD SPACE collations' => array(false, 'karen ', 'karen'),
+            'full width letter' => array(false, "\xef\xbd\x8baren", 'karen'),
+        );
+    }
+
+    public function test_isSameLogin_DoesNotFoldTheSameWayMbStrtolowerDoes()
+    {
+        // guards against a regression back to mb_strtolower(), which reports these two logins as equal
+        $kelvinKaren = "\xe2\x84\xaaaren";
+
+        $this->assertSame(mb_strtolower($kelvinKaren, 'UTF-8'), mb_strtolower('Karen', 'UTF-8'));
+        $this->assertFalse(UserIdentity::isSameLogin($kelvinKaren, 'Karen'));
+    }
+}

--- a/tests/Unit/WebServerSessionAuthTest.php
+++ b/tests/Unit/WebServerSessionAuthTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\LoginLdap\tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\AuthResult;
+use Piwik\Config;
+use Piwik\Log\LoggerInterface;
+use Piwik\Plugins\LoginLdap\Auth\WebServerSessionAuth;
+use Piwik\Session\SessionAuth;
+use Piwik\Session\SessionFingerprint;
+
+/**
+ * @group LoginLdap
+ * @group LoginLdap_Unit
+ * @group LoginLdap_WebServerSessionAuthTest
+ */
+class WebServerSessionAuthTest extends TestCase
+{
+    private const SESSION_USER = 'karen';
+
+    /**
+     * @var array
+     */
+    private $sessionBackup;
+
+    /**
+     * @var array
+     */
+    private $configBackup;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sessionBackup = $_SESSION ?? array();
+        $this->configBackup = Config::getInstance()->LoginLdap;
+
+        Config::getInstance()->LoginLdap = array(
+            'use_webserver_auth' => 1,
+            'strip_domain_from_web_auth' => 0,
+        );
+
+        $_SESSION = array(SessionFingerprint::USER_NAME_SESSION_VAR_NAME => self::SESSION_USER);
+    }
+
+    public function tearDown(): void
+    {
+        $_SESSION = $this->sessionBackup;
+        unset($_SERVER['REMOTE_USER']);
+
+        Config::getInstance()->LoginLdap = $this->configBackup;
+
+        parent::tearDown();
+    }
+
+    public function test_authenticate_UsesTheSessionAuth_IfTheWebServerAssertsTheSessionUser()
+    {
+        $_SERVER['REMOTE_USER'] = self::SESSION_USER;
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertEquals(self::SESSION_USER, $result->getIdentity());
+        $this->assertSessionWasKept();
+    }
+
+    public function test_authenticate_UsesTheSessionAuth_IfTheWebServerAssertsNobody()
+    {
+        unset($_SERVER['REMOTE_USER']);
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertSessionWasKept();
+    }
+
+    public function test_authenticate_UsesTheSessionAuth_IfThereIsNoSessionYet()
+    {
+        $_SESSION = array();
+        $_SERVER['REMOTE_USER'] = 'someoneelse';
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+    }
+
+    public function test_authenticate_UsesTheSessionAuth_IfWebServerAuthIsNotUsed()
+    {
+        Config::getInstance()->LoginLdap = array('use_webserver_auth' => 0);
+
+        $_SERVER['REMOTE_USER'] = 'someoneelse';
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertSessionWasKept();
+    }
+
+    /**
+     * @dataProvider getLoginsThatAreNotTheSessionUser
+     */
+    public function test_authenticate_EndsTheSession_IfTheWebServerAssertsSomebodyElse($remoteUser)
+    {
+        $_SERVER['REMOTE_USER'] = $remoteUser;
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = false))->authenticate();
+
+        $this->assertEquals(AuthResult::FAILURE, $result->getCode());
+        $this->assertNull($result->getIdentity());
+        $this->assertSessionWasEnded();
+    }
+
+    public function getLoginsThatAreNotTheSessionUser()
+    {
+        return array(
+            'a different user' => array('bob'),
+
+            // the session guard uses the same exact comparison WebServerAuth uses
+            'ascii case difference' => array('Karen'),
+            'accented character' => array("\xc3\xa1aren"),
+            'kelvin sign' => array("\xe2\x84\xaaaren"),
+        );
+    }
+
+    public function test_authenticate_UsesTheSessionAuth_IfOnlyTheStrippedDomainDiffers()
+    {
+        Config::getInstance()->LoginLdap = array(
+            'use_webserver_auth' => 1,
+            'strip_domain_from_web_auth' => 1,
+        );
+
+        $_SERVER['REMOTE_USER'] = 'SHIELD\\' . self::SESSION_USER;
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertSessionWasKept();
+    }
+
+    public function test_authenticate_EndsTheSession_IfTheDomainIsNotStripped()
+    {
+        $_SERVER['REMOTE_USER'] = 'SHIELD\\' . self::SESSION_USER;
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = false))->authenticate();
+
+        $this->assertEquals(AuthResult::FAILURE, $result->getCode());
+        $this->assertSessionWasEnded();
+    }
+
+    private function assertSessionWasKept()
+    {
+        $this->assertEquals(self::SESSION_USER, (new SessionFingerprint())->getUser());
+    }
+
+    private function assertSessionWasEnded()
+    {
+        $this->assertNull((new SessionFingerprint())->getUser());
+        $this->assertEquals(array(), $_SESSION);
+    }
+
+    private function makeAuth(SessionAuth $wrapped)
+    {
+        return new WebServerSessionAuth(
+            $wrapped,
+            $this->createMock(LoggerInterface::class),
+            $shouldDestroySession = false
+        );
+    }
+
+    private function makeWrappedAuth($isCalled)
+    {
+        $wrapped = $this->getMockBuilder(SessionAuth::class)
+                        ->onlyMethods(array('authenticate'))
+                        ->getMock();
+
+        $wrapped->expects($isCalled ? $this->once() : $this->never())
+                ->method('authenticate')
+                ->willReturn(new AuthResult(AuthResult::SUCCESS, self::SESSION_USER, 'atoken'));
+
+        return $wrapped;
+    }
+}


### PR DESCRIPTION
Follow-up hardening to the login check added in 5.2.6. Refs #AS-689.

### Changes

- **The login comparison no longer folds Unicode.** Users are looked up through the collation of the `login` column, and Unicode aware folding treats as equal the same values that collation does, so it cannot tell a collation-matched row apart from an exact one. Replaced with an ASCII-only fold in the new `UserIdentity::isSameLogin()`, applied in `Auth\Base` and `LdapInterop\UserSynchronizer`.
- **Web server auth requires an exact login match.** It is the one implementation that verifies no credential against the row the asserted login resolves to. Core's `SessionAuth` makes the same byte-exact check on the session user. The login is also resolved before synchronisation now, so a login resolving to a different existing user is rejected before sync writes to that user's row.
- **A session ends when the web server authenticates a different user.** `FrontController` authenticates from the session before it consults `Piwik\Auth`, so `WebServerAuth` is not consulted again while a session exists. The new `Auth\WebServerSessionAuth` decorates core's `SessionAuth` (same `DI::decorate` pattern the Cloud plugin uses) and ends the session on a mismatch, so the request falls through to `WebServerAuth` and the asserted user is logged in instead.

### Notes for reviewers

- `WebServerAuth::getAssertedLogin()` was extracted so domain stripping has a single definition shared with the session guard; the `preg_replace` moved verbatim.
- The exact-match rule is shared through `UserIdentity::isSameLoginExact()` so the session guard cannot drift from what `WebServerAuth` accepts.
- An absent `REMOTE_USER` is deliberately not treated as a mismatch, since setups that require web server auth on only some paths would otherwise log people out at random.
- The session is emptied before regeneration; `destroyCurrentSession()` only clears the fingerprint and regenerating the id copies the rest across.
- **Behaviour change:** an install where the Matomo user is `jdoe` while `REMOTE_USER` asserts `JDoe` authenticates today and will stop doing so.

### Tests

`tests/Unit/UserIdentityTest.php` and `tests/Unit/WebServerSessionAuthTest.php` are new; `tests/Integration/WebServerAuthTest.php` gains a data-provider case. Full plugin unit suite passes locally (142 tests, 339 assertions).

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
