### PR TITLE
Compares the LDAP instance identifier exactly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # LoginLdap Changelog
 
+#### LoginLdap 5.2.7
+- Fixed the LDAP instance identifier comparison, so an access value naming a different Matomo instance is no longer applied to this one
+
 #### LoginLdap 5.2.6 - 2026-08-24
 - Added strict check for TLS if enabled
 - Added strict comparison of login username

--- a/LdapInterop/UserAccessAttributeParser.php
+++ b/LdapInterop/UserAccessAttributeParser.php
@@ -259,26 +259,23 @@ class UserAccessAttributeParser
      */
     protected function isInstanceIdForThisInstance($instanceId)
     {
-        if (empty($instanceId)) {
+        $instanceId = trim($instanceId ?? '');
+
+        if ($instanceId === '') {
             return true;
         }
 
         if ($this->thisPiwikInstanceName === null) {
             $result = $this->isUrlThisInstanceUrl($instanceId);
         } else {
-            preg_match("/\\b" . preg_quote($this->thisPiwikInstanceName) . "\\b/", $instanceId, $matches);
+            $result = $instanceId === trim($this->thisPiwikInstanceName);
 
-            if (empty($matches)) {
-                $result = false;
-            } else {
-                if (strlen($matches[0]) != strlen($instanceId)) {
-                    $this->logger->debug(
-                        "UserAccessAttributeParser::{func}: Found extra characters in Piwik instance ID. Whole ID entry = {id}.",
-                        array('func' => __FUNCTION__, 'id' => $instanceId)
-                    );
-                }
-
-                $result = true;
+            if (!$result && $this->containsInstanceName($instanceId)) {
+                $this->logger->warning(
+                    "UserAccessAttributeParser::{func}: Ignoring instance ID '{id}': it contains the configured "
+                        . "instance name '{name}' but is not equal to it.",
+                    array('func' => __FUNCTION__, 'id' => $instanceId, 'name' => $this->thisPiwikInstanceName)
+                );
             }
         }
 
@@ -315,6 +312,21 @@ class UserAccessAttributeParser
         $delimiters = $this->serverIdsSeparator . $this->serverSpecificationDelimiter;
         $result = preg_split("/[" . preg_quote($delimiters) . "]/", $attributeValue);
         return array_map('trim', $result);
+    }
+
+    /**
+     * Returns whether $instanceId contains the configured instance name as a word.
+     *
+     * Only used to log identifiers that earlier versions accepted for this instance.
+     *
+     * @param string $instanceId
+     * @return bool
+     */
+    private function containsInstanceName($instanceId)
+    {
+        $pattern = "/\\b" . preg_quote(trim($this->thisPiwikInstanceName), '/') . "\\b/";
+
+        return (bool) preg_match($pattern, $instanceId);
     }
 
     /**

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "LoginLdap",
-    "version": "5.2.6",
+    "version": "5.2.7",
     "description": "LDAP authentication and synchronization for Matomo.",
     "theme": false,
     "keywords": ["ldap", "login", "authentication", "active", "directory", "kerberos", "sso"],

--- a/tests/Unit/UserAccessAttributeParserTest.php
+++ b/tests/Unit/UserAccessAttributeParserTest.php
@@ -159,8 +159,10 @@ class UserAccessAttributeParserTest extends TestCase
 
         $this->userAccessAttributeParser->setThisPiwikInstanceName("myPi|wik");
 
+        // only 'myPi|wik' is the configured instance ID. 'myPi|wik = view' and 'myPi | wik' are different
+        // identifiers and no longer contribute their sites
         $ids = $this->userAccessAttributeParser->getSiteIdsFromAccessAttribute(" ; ; myPi|wik : 1,2 ; myPi|wik = view:3,def; myPi | wik:4,5 ; ; ");
-        $this->assertEquals(array(1,2,3), $ids);
+        $this->assertEquals(array(1,2), $ids);
     }
 
     public function test_getSiteIdsFromAccessAttribute_ReturnsCorrectSiteIdList_WhenCustomDelimitersAreUsed()
@@ -226,6 +228,48 @@ class UserAccessAttributeParserTest extends TestCase
         $this->assertTrue($hasSuperUserAccess);
     }
 
+    /**
+     * @dataProvider getInstanceIdsThatAreNotThisInstance
+     */
+    public function test_getSuperUserAccessFromSuperUserAttribute_ReturnsFalse_IfInstanceIdOnlyContainsTheInstanceName($instanceId)
+    {
+        $this->userAccessAttributeParser->setThisPiwikInstanceName('matomo-prod');
+
+        $this->assertFalse($this->userAccessAttributeParser->getSuperUserAccessFromSuperUserAttribute($instanceId));
+    }
+
+    /**
+     * @dataProvider getInstanceIdsThatAreNotThisInstance
+     */
+    public function test_getSiteIdsFromAccessAttribute_ReturnsNoSites_IfInstanceIdOnlyContainsTheInstanceName($instanceId)
+    {
+        $this->userAccessAttributeParser->setThisPiwikInstanceName('matomo-prod');
+
+        $this->assertEquals(array(), $this->userAccessAttributeParser->getSiteIdsFromAccessAttribute($instanceId . ":1,2,3"));
+    }
+
+    public function getInstanceIdsThatAreNotThisInstance()
+    {
+        return array(
+            'suffix' => array('matomo-prod-eu'),
+            'prefix' => array('eu-matomo-prod'),
+            'surrounding text' => array('the matomo-prod instance'),
+            'unrelated' => array('matomo-stage'),
+
+            // '0' used to be treated as an unspecified instance ID, which matched every instance
+            'zero' => array('0'),
+        );
+    }
+
+    public function test_getSuperUserAccessFromSuperUserAttribute_ReturnsTrue_IfInstanceIdIsTheInstanceName()
+    {
+        $this->userAccessAttributeParser->setThisPiwikInstanceName('matomo-prod');
+
+        $this->assertTrue($this->userAccessAttributeParser->getSuperUserAccessFromSuperUserAttribute('matomo-prod'));
+        $this->assertTrue($this->userAccessAttributeParser->getSuperUserAccessFromSuperUserAttribute('  matomo-prod  '));
+        $this->assertTrue($this->userAccessAttributeParser->getSuperUserAccessFromSuperUserAttribute('matomo-prod-eu;matomo-prod'));
+    }
+
     public function test_getSuperUserAccessFromSuperUserAttribute_ReturnsFalse_IfInstanceNotInAttribute()
     {
         $this->userAccessAttributeParser->setThisPiwikInstanceName('myPiwik');
@@ -254,11 +298,13 @@ class UserAccessAttributeParserTest extends TestCase
     {
         $this->userAccessAttributeParser->setThisPiwikInstanceName('myPiwik');
 
+        // an instance ID is only this instance when it is exactly the configured name. Malformed values are
+        // no longer searched for the name, since that made one instance's grant apply to another.
         $hasSuperUserAccess = $this->userAccessAttributeParser->getSuperUserAccessFromSuperUserAttribute(" myPiwik = superuser ; whatever");
-        $this->assertTrue($hasSuperUserAccess);
+        $this->assertFalse($hasSuperUserAccess);
 
         $hasSuperUserAccess = $this->userAccessAttributeParser->getSuperUserAccessFromSuperUserAttribute("anothe; superuser = myPiwik ; whatever");
-        $this->assertTrue($hasSuperUserAccess);
+        $this->assertFalse($hasSuperUserAccess);
 
         $this->userAccessAttributeParser->setThisPiwikInstanceName(null);
         $this->userAccessAttributeParser->setServerSpecificationDelimiter('|');


### PR DESCRIPTION
Refs #AS-715.

### Problem

`UserAccessAttributeParser::isInstanceIdForThisInstance()` searched the supplied instance ID for the configured `instance_name` as an unanchored `\b`-delimited word instead of comparing the two. Since `-` is a non-word character, an instance named `matomo-prod` matched the identifier `matomo-prod-eu`, so an access value naming a different Matomo instance was applied to this one. The same predicate gates view/admin site access and Super User, and `UserSynchronizer` clears the account's current access before persisting what the mapper returned.

### Change

The instance ID is now compared for equality with the configured name, both trimmed. Where an identifier would previously have matched but no longer does, a WARNING names it, so a deployment that relied on the old behaviour gets a diagnosable log line rather than silently losing access.

`empty($instanceId)` became `trim($instanceId) === ''` for the unspecified-instance case. `empty()` is also true for `"0"`, so a `superuser: 0` attribute value reached this method and returned `true`, granting Super User. This is the same class of issue #431 fixed in the neighbouring empty-value check, which did not cover this path.

Verified against the parser, `instance_name = matomo-prod`:

| instance ID | before | after |
| --- | --- | --- |
| `matomo-prod` | match | match |
| `  matomo-prod  ` | match | match |
| `matomo-stage` | no match | no match |
| `matomo-prod-eu` | **match** | no match |
| `eu-matomo-prod` | **match** | no match |
| `the matomo-prod instance` | **match** | no match |

Super User attribute values, same configuration — only `0` changes:

| value | before | after |
| --- | --- | --- |
| `` (empty) | granted | granted |
| `1` / `true` / `tRuE` | granted | granted |
| `false` / `no` | denied | denied |
| `0` | **granted** | denied |

### Behaviour change

Malformed instance identifiers are no longer recovered by searching them for the instance name. The documented format is `instanceId:siteList` pairs; the class docblock only promises malformed values are *logged*, not honoured. Two existing assertions encoded the old recovery and are updated:

- `test_getSuperUserAccessFromSuperUserAttribute_ReturnsCorrectResult_IfAttributeValueIsMalformed` — `" myPiwik = superuser ; whatever"` and `"anothe; superuser = myPiwik ; whatever"` no longer grant Super User. Segments are split only on `[:;]`, so these are `myPiwik = superuser` and `superuser = myPiwik`.
- `test_getSiteIdsFromAccessAttribute_ReturnsCorrectSiteIdList_WhenAttributeValueIsMalformed` — `myPi|wik = view:3,def` no longer contributes site 3.

Default URL-based matching is untouched; `isUrlThisInstanceUrl()` already compares normalized URLs with `==`.

### Tests

Regression cases added for the suffix, prefix, surrounding-text, unrelated and `0` identifiers, over both the Super User and site-access paths, plus positive cases for the exact and whitespace-padded name. Plugin unit suite passes (132 tests, 301 assertions).

### Note

Overlaps with #482, which also bumps `plugin.json` to 5.2.7 and adds a CHANGELOG heading. Whichever merges second needs a trivial rebase on those two files.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?