### PR TITLE
Port AS-689 follow-up hardening to 6.x

### DIFF
--- a/Auth/Base.php
+++ b/Auth/Base.php
@@ -17,6 +17,7 @@ use Piwik\Piwik;
 use Piwik\Plugins\LoginLdap\Config;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserSynchronizer;
 use Piwik\Plugins\LoginLdap\Model\LdapUsers;
+use Piwik\Plugins\LoginLdap\UserIdentity;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 use Piwik\Plugins\UsersManager\Model as UserModel;
 use Piwik\Log\LoggerInterface;
@@ -287,7 +288,17 @@ abstract class Base implements Auth
             if (!empty($this->login)) {
                 $user = $this->usersModel->getUser($this->login);
 
-                if (!empty($user) && !$this->isSameLogin($this->login, $user['login'])) {
+                if (!empty($user) && !UserIdentity::isSameLogin($this->login, $user['login'])) {
+                    $this->logger->warning(
+                        "Auth\\Base::{func}: refusing to authenticate '{assertedLogin}': it resolves to the "
+                            . "existing Matomo user '{storedLogin}', which is a different login.",
+                        array(
+                            'func' => __FUNCTION__,
+                            'assertedLogin' => $this->login,
+                            'storedLogin' => $user['login'],
+                        )
+                    );
+
                     throw new Exception(sprintf(
                         "Refusing to authenticate: asserted login '%s' resolved to the different existing user '%s'.",
                         $this->login,
@@ -303,11 +314,6 @@ abstract class Base implements Auth
             }
         }
         return $this->userForLogin;
-    }
-
-    private function isSameLogin(string $assertedLogin, string $storedLogin): bool
-    {
-        return mb_strtolower($assertedLogin, 'UTF-8') === mb_strtolower($storedLogin, 'UTF-8');
     }
 
     protected function tryFallbackAuth($onlySuperUsers = true, ?Auth $auth = null)

--- a/Auth/WebServerAuth.php
+++ b/Auth/WebServerAuth.php
@@ -63,21 +63,21 @@ class WebServerAuth extends Base
     public function authenticate()
     {
         try {
-            $webServerAuthUser = $this->getAlreadyAuthenticatedLogin();
+            $webServerAuthUser = self::getAlreadyAuthenticatedLogin();
 
             if (empty($webServerAuthUser)) {
                 $this->logger->debug("using web server authentication, but REMOTE_USER server variable not found.");
 
                 return $this->tryFallbackAuth($onlySuperUsers = false, $this->fallbackAuth);
             } else {
-                if (Config::getStripDomainFromWebAuth()) {
-                    $this->login = preg_replace('/(.*?\\\\)|(@.*)/', '', $webServerAuthUser);
-                } else {
-                    $this->login = $webServerAuthUser;
-                }
+                $this->login = self::getAssertedLogin();
                 $this->password = '';
 
                 $this->logger->info("User '{login}' authenticated by webserver.", array('login' => $this->login));
+
+                // resolve the login before synchronizing, so that a login resolving to a different existing
+                // user is rejected before synchronization writes to that user's row
+                $this->getUserForLogin();
 
                 if ($this->synchronizeUsersAfterSuccessfulLogin) {
                     $this->synchronizeLoggedInUser();
@@ -146,15 +146,53 @@ class WebServerAuth extends Base
         $this->fallbackAuth = $fallbackAuth;
     }
 
-    private function getAlreadyAuthenticatedLogin()
+    private static function getAlreadyAuthenticatedLogin()
     {
         return @$_SERVER['REMOTE_USER'];
     }
 
+    /**
+     * Returns the login the web server authenticated for this request, or null when it authenticated nobody.
+     *
+     * The single answer to "who does the web server say this is", so that authentication, the session guard
+     * and {@link self::isCurrentRequestWebServerAuthenticated()} cannot disagree about it.
+     *
+     * The value is returned as the web server gave it. Trimming it here would let "ironman " authenticate as
+     * "ironman", which is a row the login column's collation returns for it and which the login comparison
+     * exists to refuse. Trimming decides only whether anybody was asserted at all, so that a REMOTE_USER of
+     * "  ", or one that strips to nothing such as "SHIELD\\", names nobody rather than the empty login.
+     *
+     * @return string|null
+     */
+    public static function getAssertedLogin(): ?string
+    {
+        $webServerAuthUser = self::getAlreadyAuthenticatedLogin();
+
+        if (empty($webServerAuthUser)) {
+            return null;
+        }
+
+        if (Config::getStripDomainFromWebAuth()) {
+            $webServerAuthUser = preg_replace('/(.*?\\\\)|(@.*)/', '', $webServerAuthUser);
+        }
+
+        return trim($webServerAuthUser) === '' ? null : $webServerAuthUser;
+    }
+
+    /**
+     * Returns whether the web server authenticated somebody for this request.
+     *
+     * Callers use this to skip Matomo's own password confirmation, so it has to agree with
+     * {@link self::getAssertedLogin()}: an assertion naming nobody authenticates nobody, and must not skip
+     * anything.
+     *
+     * @return bool
+     */
     public static function isCurrentRequestWebServerAuthenticated(): bool
     {
         $auth = StaticContainer::get('Piwik\Auth');
-        return $auth instanceof WebServerAuth && !empty($_SERVER['REMOTE_USER']);
+
+        return $auth instanceof WebServerAuth && self::getAssertedLogin() !== null;
     }
 
     private function synchronizeLoggedInUser()

--- a/Auth/WebServerSessionAuth.php
+++ b/Auth/WebServerSessionAuth.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\LoginLdap\Auth;
+
+use Piwik\AuthResult;
+use Piwik\Container\StaticContainer;
+use Piwik\Log\LoggerInterface;
+use Piwik\Plugins\LoginLdap\Config;
+use Piwik\Plugins\LoginLdap\UserIdentity;
+use Piwik\Session\SessionAuth;
+use Piwik\Session\SessionFingerprint;
+
+/**
+ * Decorates the core session authentication so that a Matomo session cannot outlive the web server identity
+ * it was created for.
+ *
+ * FrontController authenticates from the session before it consults `Piwik\Auth`, and skips the configured
+ * auth implementation when that succeeds, so {@link WebServerAuth} is not consulted again while a session
+ * exists. Ending the session on a mismatch makes FrontController fall through to WebServerAuth, which then
+ * logs the newly asserted user in.
+ */
+class WebServerSessionAuth extends SessionAuth
+{
+    /**
+     * @var SessionAuth
+     */
+    private $wrapped;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param SessionAuth $wrapped
+     * @param LoggerInterface|null $logger
+     * @param bool $shouldDestroySession For tests, since there is no actual session there.
+     */
+    public function __construct(SessionAuth $wrapped, ?LoggerInterface $logger = null, $shouldDestroySession = true)
+    {
+        parent::__construct(null, $shouldDestroySession);
+
+        $this->wrapped = $wrapped;
+        $this->logger = $logger ?: StaticContainer::get(LoggerInterface::class);
+    }
+
+    public function authenticate()
+    {
+        $sessionUser = $this->getSessionUserToEndFor();
+
+        if ($sessionUser === null) {
+            return $this->wrapped->authenticate();
+        }
+
+        $this->logger->info(
+            "WebServerSessionAuth::{func}: ending the session of '{sessionUser}', the web server now "
+                . "authenticates '{assertedUser}'.",
+            array(
+                'func' => __FUNCTION__,
+                'sessionUser' => $sessionUser,
+                'assertedUser' => WebServerAuth::getAssertedLogin(),
+            )
+        );
+
+        $this->endSession();
+
+        return new AuthResult(AuthResult::FAILURE, '', '');
+    }
+
+    /**
+     * Returns the session's user when the web server now authenticates somebody else, null otherwise.
+     *
+     * The wrapped session auth is deliberately not run first, so that on a mismatch nothing of the previous
+     * user is left on this instance for FrontController to read back.
+     *
+     * @return string|null
+     */
+    private function getSessionUserToEndFor(): ?string
+    {
+        if (!Config::shouldUseWebServerAuthentication()) {
+            return null;
+        }
+
+        $assertedLogin = WebServerAuth::getAssertedLogin();
+
+        // an absent REMOTE_USER is not a mismatch: setups that require web server authentication on only some
+        // paths would otherwise log people out at random. getAssertedLogin() also reports one that names
+        // nobody as absent, so this and WebServerAuth agree on every value.
+        //
+        // A REMOTE_USER that only differs from the session's user by surrounding whitespace is a mismatch and
+        // ends the session, as it would be for any other login WebServerAuth refuses to authenticate.
+        if ($assertedLogin === null) {
+            return null;
+        }
+
+        $sessionUser = (new SessionFingerprint())->getUser();
+
+        if (empty($sessionUser) || UserIdentity::isSameLogin($assertedLogin, $sessionUser)) {
+            return null;
+        }
+
+        return $sessionUser;
+    }
+
+    /**
+     * Empties the session before regenerating it.
+     *
+     * `destroyCurrentSession()` only clears the session fingerprint, and regenerating the id copies the
+     * remaining session data across, which would hand the previous user's namespaces to the new one.
+     */
+    private function endSession(): void
+    {
+        // not gated on Session::isSessionStarted(): Session::start() returns before setting that flag when a
+        // session is already active, so the flag can be false while $_SESSION holds the previous user's data
+        $_SESSION = array();
+
+        $this->destroyCurrentSession(new SessionFingerprint());
+    }
+
+    public function getName()
+    {
+        return $this->wrapped->getName();
+    }
+
+    public function setTokenAuth(
+        #[\SensitiveParameter]
+        $token_auth
+    ) {
+        $this->wrapped->setTokenAuth($token_auth);
+    }
+
+    public function getLogin()
+    {
+        return $this->wrapped->getLogin();
+    }
+
+    public function getTokenAuth()
+    {
+        return $this->wrapped->getTokenAuth();
+    }
+
+    public function getTokenAuthSecret()
+    {
+        return $this->wrapped->getTokenAuthSecret();
+    }
+
+    public function setLogin($login)
+    {
+        $this->wrapped->setLogin($login);
+    }
+
+    public function setPassword(
+        #[\SensitiveParameter]
+        $password
+    ) {
+        $this->wrapped->setPassword($password);
+    }
+
+    public function setPasswordHash(
+        #[\SensitiveParameter]
+        $passwordHash
+    ) {
+        $this->wrapped->setPasswordHash($passwordHash);
+    }
+
+    public function wasSessionExpired(): bool
+    {
+        return $this->wrapped->wasSessionExpired();
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 #### LoginLdap 6.0.2
 * Fixed the LDAP instance identifier comparison, so an access value naming a different Matomo instance is no longer applied to this one
 * Fixed the loading indicator showing as a white box in dark mode
+* Fixed the login comparison so that logins the database collation treats as equal, but which are different users, are no longer accepted
+* Added termination of a Matomo session when the web server starts authenticating a different user
 
 #### LoginLdap 6.0.1 - 2026-09-07
 * Fixed LDAP site access being denied when the instance name or a server separator contains a slash

--- a/LdapInterop/UserSynchronizer.php
+++ b/LdapInterop/UserSynchronizer.php
@@ -17,6 +17,7 @@ use Piwik\Date;
 use Piwik\Db;
 use Piwik\Piwik;
 use Piwik\Plugins\LoginLdap\Config;
+use Piwik\Plugins\LoginLdap\UserIdentity;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 use Piwik\Plugins\UsersManager\Model as UserModel;
 use Piwik\Plugins\UsersManager\UserUpdater;
@@ -145,11 +146,10 @@ class UserSynchronizer
                 'ldapLogin' => $user['login']
             ));
 
-            if (!empty($existingUser) && mb_strtolower($existingUser['login']) !== mb_strtolower($user['login'])) {
+            if (!empty($existingUser) && !UserIdentity::isSameLogin($user['login'], $existingUser['login'])) {
                 $logger->warning(
                     "UserSynchronizer::{func}: refusing to synchronize LDAP user '{ldapLogin}': it resolves to the "
-                        . "existing Matomo user '{existingLogin}', which is a different login. This usually means two "
-                        . "LDAP identities differing by accent map onto one Matomo login.",
+                        . "existing Matomo user '{existingLogin}', which is a different login.",
                     array(
                         'func' => 'synchronizeLdapUser',
                         'ldapLogin' => $user['login'],

--- a/LoginLdap.php
+++ b/LoginLdap.php
@@ -259,11 +259,10 @@ class LoginLdap extends \Piwik\Plugin
             return;
         }
 
-        // Only a web-server-authenticated request bypasses the password. When REMOTE_USER is
-        // absent, WebServerAuth delegates to its password-validating fallback, so token
-        // creation stays safe and must remain allowed.
-        $auth = StaticContainer::get('Piwik\Auth');
-        if ($auth instanceof WebServerAuth && !empty($_SERVER['REMOTE_USER'])) {
+        // Only a web-server-authenticated request bypasses the password. When the web server authenticated
+        // nobody, WebServerAuth delegates to its password-validating fallback, so token creation stays safe
+        // and must remain allowed.
+        if (WebServerAuth::isCurrentRequestWebServerAuthenticated()) {
             throw new Exception(Piwik::translate('LoginLdap_CreateAppSpecificTokenAuthBlocked'));
         }
     }

--- a/UserIdentity.php
+++ b/UserIdentity.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\LoginLdap;
+
+/**
+ * Compares an asserted login with the login of the Matomo user it resolved to.
+ *
+ * Users are looked up through the collation of the `login` column, so a lookup can return a row whose login
+ * only collates the same as the asserted one. These comparisons decide whether such a row may be used.
+ */
+class UserIdentity
+{
+    /**
+     * Returns true if the asserted login and the stored login identify the same Matomo user.
+     *
+     * Only ASCII case differences are tolerated, since LDAP directories match user ids case insensitively.
+     * Unicode aware folding must not be used here, as it treats as equal the same values the collation does.
+     *
+     * @param string $assertedLogin The login the authentication attempt was made with.
+     * @param string $storedLogin The login of the user row the lookup returned.
+     * @return bool
+     */
+    public static function isSameLogin(string $assertedLogin, string $storedLogin): bool
+    {
+        return self::asciiLower($assertedLogin) === self::asciiLower($storedLogin);
+    }
+
+    /**
+     * Lowercases the ASCII letters in $value and leaves every other byte untouched.
+     *
+     * strtolower() is not used since it is locale aware on PHP versions before 8.2 and can fold bytes outside
+     * of ASCII.
+     *
+     * @param string $value
+     * @return string
+     */
+    private static function asciiLower(string $value): string
+    {
+        return strtr($value, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+    }
+}

--- a/config/config.php
+++ b/config/config.php
@@ -8,6 +8,11 @@
  */
 
 return [
+    // keeps a Matomo session from outliving the web server identity it was created for
+    \Piwik\Session\SessionAuth::class => \Piwik\DI::decorate(function (\Piwik\Session\SessionAuth $previous) {
+        return new \Piwik\Plugins\LoginLdap\Auth\WebServerSessionAuth($previous);
+    }),
+
     'observers.global' => \Piwik\DI::add([
         ['Login.userRequiresPasswordConfirmation', \Piwik\DI::value(function (&$requiresPasswordConfirmation, $login) {
             if (\Piwik\Plugins\LoginLdap\Auth\WebServerAuth::isCurrentRequestWebServerAuthenticated()) {

--- a/tests/Integration/WebServerAuthTest.php
+++ b/tests/Integration/WebServerAuthTest.php
@@ -70,6 +70,60 @@ class WebServerAuthTest extends LdapIntegrationTest
         $this->assertEquals(0, $authResult->getCode());
     }
 
+    /**
+     * @dataProvider getLoginsResolvingToTheSuperUser
+     */
+    public function test_WebServerAuth_Fails_IfAssertedLoginResolvesToDifferentExistingUser($remoteUser)
+    {
+        Config::getInstance()->LoginLdap['use_webserver_auth'] = 1;
+
+        // each of these resolves to the existing super user through the collation of the login column, but the
+        // web server authenticated a different principal
+        $_SERVER['REMOTE_USER'] = $remoteUser;
+
+        $ldapAuth = WebServerAuth::makeConfigured();
+        $authResult = $ldapAuth->authenticate();
+
+        $this->assertEquals(AuthResult::FAILURE, $authResult->getCode());
+        $this->assertNotEquals(self::TEST_SUPERUSER_LOGIN, $authResult->getIdentity());
+    }
+
+    public function getLoginsResolvingToTheSuperUser()
+    {
+        return array(
+            'accented character' => array(substr(self::TEST_SUPERUSER_LOGIN, 0, -1) . "\xc3\xa1"),
+        );
+    }
+
+    public function test_WebServerAuth_Works_IfAssertedLoginDiffersFromTheStoredOneOnlyByAsciiCase()
+    {
+        Config::getInstance()->LoginLdap['use_webserver_auth'] = 1;
+
+        $_SERVER['REMOTE_USER'] = strtoupper(self::TEST_SUPERUSER_LOGIN);
+
+        $ldapAuth = WebServerAuth::makeConfigured();
+        $authResult = $ldapAuth->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS_SUPERUSER_AUTH_CODE, $authResult->getCode());
+        $this->assertEquals(self::TEST_SUPERUSER_LOGIN, $authResult->getIdentity());
+    }
+
+    public function test_WebServerAuth_Works_OnEveryRequest_IfTheUserIsProvisionedFromADifferentlyCasedLogin()
+    {
+        Config::getInstance()->LoginLdap['use_webserver_auth'] = 1;
+
+        // the Matomo user does not exist yet, so it is created from the LDAP entry's own casing. Every later
+        // request asserts the login the web server has, which must keep resolving to that user.
+        $_SERVER['REMOTE_USER'] = strtoupper(self::TEST_LOGIN);
+
+        foreach (array('first', 'second') as $request) {
+            $authResult = WebServerAuth::makeConfigured()->authenticate();
+
+            $this->assertEquals(AuthResult::SUCCESS, $authResult->getCode(), "failed on the {$request} request");
+            $this->assertEquals(self::TEST_LOGIN, $authResult->getIdentity());
+        }
+    }
+
     public function test_WebServerAuth_Fails_IfUserIsNotPartOfRequiredGroup()
     {
         Config::getInstance()->LoginLdap['use_webserver_auth'] = 1;

--- a/tests/Unit/UserIdentityTest.php
+++ b/tests/Unit/UserIdentityTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\LoginLdap\tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\Plugins\LoginLdap\UserIdentity;
+
+/**
+ * @group LoginLdap
+ * @group LoginLdap_Unit
+ * @group LoginLdap_UserIdentityTest
+ */
+class UserIdentityTest extends TestCase
+{
+    /**
+     * @dataProvider getLoginsToCompare
+     */
+    public function test_isSameLogin_ComparesLoginsWithoutUnicodeFolding($expected, $assertedLogin, $storedLogin)
+    {
+        $this->assertSame($expected, UserIdentity::isSameLogin($assertedLogin, $storedLogin));
+    }
+
+    public function getLoginsToCompare()
+    {
+        return array(
+            'identical' => array(true, 'karen', 'karen'),
+            'ascii case difference' => array(true, 'Karen', 'karen'),
+            'ascii case difference, other way round' => array(true, 'karen', 'KAREN'),
+            'different logins' => array(false, 'karen', 'bob'),
+
+            // the collation of the login column equates these pairs, as does mb_strtolower()
+            'kelvin sign' => array(false, "\xe2\x84\xaaaren", 'Karen'),
+            'angstrom sign' => array(false, "\xe2\x84\xabngus", 'Ångus'),
+            'accent' => array(false, 'josé', 'jose'),
+            'sharp s' => array(false, 'straße', 'strasse'),
+            'trailing space, PAD SPACE collations' => array(false, 'karen ', 'karen'),
+            'full width letter' => array(false, "\xef\xbd\x8baren", 'karen'),
+        );
+    }
+
+    public function test_isSameLogin_DoesNotFoldTheSameWayMbStrtolowerDoes()
+    {
+        // guards against a regression back to mb_strtolower(), which reports these two logins as equal
+        $kelvinKaren = "\xe2\x84\xaaaren";
+
+        $this->assertSame(mb_strtolower($kelvinKaren, 'UTF-8'), mb_strtolower('Karen', 'UTF-8'));
+        $this->assertFalse(UserIdentity::isSameLogin($kelvinKaren, 'Karen'));
+    }
+}

--- a/tests/Unit/WebServerAuthAssertionTest.php
+++ b/tests/Unit/WebServerAuthAssertionTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\LoginLdap\tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\Config;
+use Piwik\Container\StaticContainer;
+use Piwik\Log\LoggerInterface;
+use Piwik\Plugins\LoginLdap\Auth\WebServerAuth;
+
+/**
+ * @group LoginLdap
+ * @group LoginLdap_Unit
+ * @group LoginLdap_WebServerAuthAssertionTest
+ */
+class WebServerAuthAssertionTest extends TestCase
+{
+    /**
+     * @var array
+     */
+    private $configBackup;
+
+    /**
+     * @var mixed
+     */
+    private $authBackup;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configBackup = Config::getInstance()->LoginLdap;
+        $this->authBackup = StaticContainer::get('Piwik\Auth');
+
+        Config::getInstance()->LoginLdap = array(
+            'use_webserver_auth' => 1,
+            'strip_domain_from_web_auth' => 1,
+        );
+
+        StaticContainer::getContainer()->set('Piwik\Auth', new WebServerAuth($this->createMock(LoggerInterface::class)));
+    }
+
+    public function tearDown(): void
+    {
+        unset($_SERVER['REMOTE_USER']);
+        StaticContainer::getContainer()->set('Piwik\Auth', $this->authBackup);
+        Config::getInstance()->LoginLdap = $this->configBackup;
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider getAssertionsNamingNobody
+     */
+    public function test_getAssertedLogin_ReturnsNull_IfTheAssertionNamesNobody($remoteUser)
+    {
+        $_SERVER['REMOTE_USER'] = $remoteUser;
+
+        $this->assertNull(WebServerAuth::getAssertedLogin());
+    }
+
+    /**
+     * Callers skip Matomo's password confirmation on the strength of this, so an assertion that authenticates
+     * nobody must not report the request as web server authenticated.
+     *
+     * @dataProvider getAssertionsNamingNobody
+     */
+    public function test_isCurrentRequestWebServerAuthenticated_IsFalse_IfTheAssertionNamesNobody($remoteUser)
+    {
+        $_SERVER['REMOTE_USER'] = $remoteUser;
+
+        $this->assertFalse(WebServerAuth::isCurrentRequestWebServerAuthenticated());
+    }
+
+    public function getAssertionsNamingNobody()
+    {
+        return array(
+            'absent' => array(null),
+            'empty' => array(''),
+            'whitespace only' => array('   '),
+            'domain only' => array('SHIELD\\'),
+            'at sign only' => array('@shield.org'),
+        );
+    }
+
+    /**
+     * @dataProvider getAssertionsNamingSomebody
+     */
+    public function test_getAssertedLogin_ReturnsTheLoginUntrimmed($expected, $remoteUser)
+    {
+        $_SERVER['REMOTE_USER'] = $remoteUser;
+
+        $this->assertSame($expected, WebServerAuth::getAssertedLogin());
+        $this->assertTrue(WebServerAuth::isCurrentRequestWebServerAuthenticated());
+    }
+
+    public function getAssertionsNamingSomebody()
+    {
+        return array(
+            'plain' => array('ironman', 'ironman'),
+            'domain stripped' => array('ironman', 'SHIELD\\ironman'),
+            'suffix stripped' => array('ironman', 'ironman@shield.org'),
+
+            // surrounding whitespace is part of the asserted identity, not noise to be cleaned up: the login
+            // column's collation returns 'ironman' for 'ironman ', and trimming would authenticate that user
+            'trailing space kept' => array('ironman ', 'ironman '),
+            'leading space kept' => array(' ironman', ' ironman'),
+        );
+    }
+}

--- a/tests/Unit/WebServerAuthLoginResolutionTest.php
+++ b/tests/Unit/WebServerAuthLoginResolutionTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\LoginLdap\tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\AuthResult;
+use Piwik\Config;
+use Piwik\Log\LoggerInterface;
+use Piwik\Plugins\LoginLdap\Auth\WebServerAuth;
+use Piwik\Plugins\LoginLdap\LdapInterop\UserSynchronizer;
+use Piwik\Plugins\LoginLdap\Model\LdapUsers;
+use Piwik\Plugins\UsersManager\Model as UserModel;
+
+/**
+ * @group LoginLdap
+ * @group LoginLdap_Unit
+ * @group LoginLdap_WebServerAuthLoginResolutionTest
+ */
+class WebServerAuthLoginResolutionTest extends TestCase
+{
+    private const LDAP_LOGIN = 'ironman';
+
+    /**
+     * @var array
+     */
+    private $configBackup;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configBackup = Config::getInstance()->LoginLdap;
+        Config::getInstance()->LoginLdap = array(
+            'use_webserver_auth' => 1,
+            'strip_domain_from_web_auth' => 0,
+        );
+    }
+
+    public function tearDown(): void
+    {
+        unset($_SERVER['REMOTE_USER']);
+        Config::getInstance()->LoginLdap = $this->configBackup;
+
+        parent::tearDown();
+    }
+
+    /**
+     * The Matomo user does not exist yet, so synchronization creates it from the LDAP entry's own casing.
+     * Every later request asserts whatever the web server has, which has to keep resolving to that user.
+     */
+    public function test_authenticate_Succeeds_OnEveryRequest_IfTheUserWasProvisionedFromADifferentlyCasedLogin()
+    {
+        $_SERVER['REMOTE_USER'] = strtoupper(self::LDAP_LOGIN);
+
+        $provisioning = $this->makeAuth($existingUser = array());
+        $this->assertEquals(AuthResult::SUCCESS, $provisioning->authenticate()->getCode());
+
+        $laterRequest = $this->makeAuth($this->makeUserRow());
+        $result = $laterRequest->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertEquals(self::LDAP_LOGIN, $result->getIdentity());
+    }
+
+    public function test_authenticate_Succeeds_IfAssertedLoginDiffersFromTheStoredOneOnlyByAsciiCase()
+    {
+        $_SERVER['REMOTE_USER'] = 'IronMan';
+
+        $result = $this->makeAuth($this->makeUserRow())->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertEquals(self::LDAP_LOGIN, $result->getIdentity());
+    }
+
+    /**
+     * @dataProvider getLoginsResolvingToADifferentUser
+     */
+    public function test_authenticate_Fails_IfAssertedLoginResolvesToADifferentUser($remoteUser)
+    {
+        $_SERVER['REMOTE_USER'] = $remoteUser;
+
+        $result = $this->makeAuth($this->makeUserRow())->authenticate();
+
+        $this->assertEquals(AuthResult::FAILURE, $result->getCode());
+    }
+
+    public function getLoginsResolvingToADifferentUser()
+    {
+        // the login column's collation returns the stored user for each of these, but they are not it
+        return array(
+            'accented character' => array("ironm\xc3\xa1n"),
+            'kelvin sign' => array("\xe2\x84\xaaironman"),
+            'a different user' => array('thanos'),
+
+            // PAD SPACE collations return the stored user for these, so they must not be trimmed into it
+            'trailing space' => array(self::LDAP_LOGIN . ' '),
+            'leading space' => array(' ' . self::LDAP_LOGIN),
+        );
+    }
+
+    private function makeUserRow()
+    {
+        return array('login' => self::LDAP_LOGIN, 'superuser_access' => 0, 'password' => 'whatever');
+    }
+
+    /**
+     * @param array $existingUser the Matomo user row before this authentication, empty when there is none yet
+     */
+    private function makeAuth($existingUser)
+    {
+        $auth = new WebServerAuth($this->createMock(LoggerInterface::class));
+
+        // synchronization creates the user when there is none, so the row is only absent until it runs
+        $userExists = !empty($existingUser);
+
+        $usersModel = $this->getMockBuilder(UserModel::class)
+                           ->onlyMethods(array('getUser', 'generateRandomTokenAuth'))
+                           ->getMock();
+        $usersModel->method('getUser')->willReturnCallback(function () use (&$userExists) {
+            return $userExists ? $this->makeUserRow() : array();
+        });
+        $usersModel->method('generateRandomTokenAuth')->willReturn('atoken');
+        $auth->setUsersModel($usersModel);
+
+        $ldapUsers = $this->getMockBuilder(LdapUsers::class)
+                          ->disableOriginalConstructor()
+                          ->onlyMethods(array('getUser'))
+                          ->getMock();
+        $ldapUsers->method('getUser')->willReturn(array('uid' => array(self::LDAP_LOGIN)));
+        $auth->setLdapUsers($ldapUsers);
+
+        $synchronizer = $this->getMockBuilder(UserSynchronizer::class)
+                             ->onlyMethods(array('synchronizeLdapUser', 'synchronizePiwikAccessFromLdap'))
+                             ->getMock();
+        $synchronizer->method('synchronizeLdapUser')->willReturnCallback(function () use (&$userExists) {
+            $userExists = true;
+
+            return $this->makeUserRow();
+        });
+        $auth->setUserSynchronizer($synchronizer);
+
+        return $auth;
+    }
+}

--- a/tests/Unit/WebServerSessionAuthTest.php
+++ b/tests/Unit/WebServerSessionAuthTest.php
@@ -1,0 +1,240 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\LoginLdap\tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\AuthResult;
+use Piwik\Config;
+use Piwik\Log\LoggerInterface;
+use Piwik\Plugins\LoginLdap\Auth\WebServerSessionAuth;
+use Piwik\Session\SessionAuth;
+use Piwik\Session\SessionFingerprint;
+
+/**
+ * @group LoginLdap
+ * @group LoginLdap_Unit
+ * @group LoginLdap_WebServerSessionAuthTest
+ */
+class WebServerSessionAuthTest extends TestCase
+{
+    private const SESSION_USER = 'karen';
+    private const OTHER_SESSION_NAMESPACE = 'Piwik_Login';
+
+    /**
+     * @var array
+     */
+    private $sessionBackup;
+
+    /**
+     * @var array
+     */
+    private $configBackup;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sessionBackup = $_SESSION ?? array();
+        $this->configBackup = Config::getInstance()->LoginLdap;
+
+        Config::getInstance()->LoginLdap = array(
+            'use_webserver_auth' => 1,
+            'strip_domain_from_web_auth' => 0,
+        );
+
+        $_SESSION = array(
+            SessionFingerprint::USER_NAME_SESSION_VAR_NAME => self::SESSION_USER,
+            // a namespace belonging to the session's user that SessionFingerprint::clear() does not touch,
+            // so that the tests can tell the wipe in endSession() from clear() emptying the array by itself
+            self::OTHER_SESSION_NAMESPACE => array('redirectParams' => 'whatever'),
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $_SESSION = $this->sessionBackup;
+        unset($_SERVER['REMOTE_USER']);
+
+        Config::getInstance()->LoginLdap = $this->configBackup;
+
+        parent::tearDown();
+    }
+
+    public function test_authenticate_UsesTheSessionAuth_IfTheWebServerAssertsTheSessionUser()
+    {
+        $_SERVER['REMOTE_USER'] = self::SESSION_USER;
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertEquals(self::SESSION_USER, $result->getIdentity());
+        $this->assertSessionWasKept();
+    }
+
+    public function test_authenticate_UsesTheSessionAuth_IfTheWebServerAssertsNobody()
+    {
+        unset($_SERVER['REMOTE_USER']);
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertSessionWasKept();
+    }
+
+    public function test_authenticate_UsesTheSessionAuth_IfThereIsNoSessionYet()
+    {
+        $_SESSION = array();
+
+        $_SERVER['REMOTE_USER'] = 'someoneelse';
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+    }
+
+    public function test_authenticate_UsesTheSessionAuth_IfWebServerAuthIsNotUsed()
+    {
+        Config::getInstance()->LoginLdap = array('use_webserver_auth' => 0);
+
+        $_SERVER['REMOTE_USER'] = 'someoneelse';
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertSessionWasKept();
+    }
+
+    /**
+     * @dataProvider getLoginsThatAreNotTheSessionUser
+     */
+    public function test_authenticate_EndsTheSession_IfTheWebServerAssertsSomebodyElse($remoteUser)
+    {
+        $_SERVER['REMOTE_USER'] = $remoteUser;
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = false))->authenticate();
+
+        $this->assertEquals(AuthResult::FAILURE, $result->getCode());
+        $this->assertSame('', $result->getIdentity());
+        $this->assertSessionWasEnded();
+    }
+
+    public function getLoginsThatAreNotTheSessionUser()
+    {
+        return array(
+            'a different user' => array('bob'),
+
+            // the session guard uses the same comparison WebServerAuth uses, so a session it keeps is always
+            // one WebServerAuth would authenticate
+            'accented character' => array("\xc3\xa1aren"),
+            'kelvin sign' => array("\xe2\x84\xaaaren"),
+
+            // not trimmed into the session's user, for the same reason WebServerAuth will not authenticate it
+            'surrounding whitespace' => array(' ' . self::SESSION_USER . ' '),
+        );
+    }
+
+    public function test_authenticate_UsesTheSessionAuth_IfTheAssertedLoginDiffersOnlyByAsciiCase()
+    {
+        $_SERVER['REMOTE_USER'] = ucfirst(self::SESSION_USER);
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertSessionWasKept();
+    }
+
+    /**
+     * @dataProvider getRemoteUsersThatStripToNothing
+     */
+    public function test_authenticate_UsesTheSessionAuth_IfTheAssertedLoginStripsToNothing($remoteUser)
+    {
+        Config::getInstance()->LoginLdap = array(
+            'use_webserver_auth' => 1,
+            'strip_domain_from_web_auth' => 1,
+        );
+
+        $_SERVER['REMOTE_USER'] = $remoteUser;
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertSessionWasKept();
+    }
+
+    public function getRemoteUsersThatStripToNothing()
+    {
+        return array(
+            'domain only' => array('SHIELD\\'),
+            'at sign only' => array('@shield.org'),
+            'whitespace only' => array('   '),
+        );
+    }
+
+    public function test_authenticate_UsesTheSessionAuth_IfOnlyTheStrippedDomainDiffers()
+    {
+        Config::getInstance()->LoginLdap = array(
+            'use_webserver_auth' => 1,
+            'strip_domain_from_web_auth' => 1,
+        );
+
+        $_SERVER['REMOTE_USER'] = 'SHIELD\\' . self::SESSION_USER;
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertSessionWasKept();
+    }
+
+    public function test_authenticate_EndsTheSession_IfTheDomainIsNotStripped()
+    {
+        $_SERVER['REMOTE_USER'] = 'SHIELD\\' . self::SESSION_USER;
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = false))->authenticate();
+
+        $this->assertEquals(AuthResult::FAILURE, $result->getCode());
+        $this->assertSessionWasEnded();
+    }
+
+    private function assertSessionWasKept()
+    {
+        $this->assertEquals(self::SESSION_USER, (new SessionFingerprint())->getUser());
+        $this->assertArrayHasKey(self::OTHER_SESSION_NAMESPACE, $_SESSION);
+    }
+
+    private function assertSessionWasEnded()
+    {
+        $this->assertNull((new SessionFingerprint())->getUser());
+        $this->assertArrayNotHasKey(self::OTHER_SESSION_NAMESPACE, $_SESSION);
+        $this->assertEquals(array(), $_SESSION);
+    }
+
+    private function makeAuth(SessionAuth $wrapped)
+    {
+        return new WebServerSessionAuth(
+            $wrapped,
+            $this->createMock(LoggerInterface::class),
+            $shouldDestroySession = false
+        );
+    }
+
+    private function makeWrappedAuth($isCalled)
+    {
+        $wrapped = $this->getMockBuilder(SessionAuth::class)
+                        ->onlyMethods(array('authenticate'))
+                        ->getMock();
+
+        $wrapped->expects($isCalled ? $this->once() : $this->never())
+                ->method('authenticate')
+                ->willReturn(new AuthResult(AuthResult::SUCCESS, self::SESSION_USER, 'atoken'));
+
+        return $wrapped;
+    }
+}


### PR DESCRIPTION
Ports #482 **and** #487 to 6.x-dev. Refs #AS-689.

Rebuilt on the current 6.x-dev tip: the branch previously carried only #482, which included the byte-exact login match that #487 removed, so it should not have merged as it stood. It is now a cherry-pick of all four AS-689 commits from 5.x (`148556b`, `397a653`, `e596d61`, `5778c30`), squashed.

### Changes

- The login comparison no longer folds Unicode, replaced with an ASCII-only fold in the new `UserIdentity::isSameLogin()`, applied in `Auth\Base` and `LdapInterop\UserSynchronizer`. The refusal logs at `warning` so a locked-out user is visible at the default log level.
- Web server auth resolves the login before synchronizing, so a login resolving to a different existing user is rejected before sync writes to that user's row.
- `Auth\WebServerSessionAuth` ends a Matomo session when the web server starts authenticating a different user, via the same `DI::decorate` pattern the Cloud plugin uses.
- `WebServerAuth::getAssertedLogin()` is the single answer to who the web server asserted. It returns the value as given — trimming it would let `ironman ` authenticate `ironman`, which the collation returns for it — and trims only to decide whether anybody was asserted. `isCurrentRequestWebServerAuthenticated()` and the `createAppSpecificTokenAuth` guard now go through it, so an assertion naming nobody no longer skips Matomo's password confirmation.

### Differences from the 5.x commits

Three, all deliberate:

1. Version and changelog folded into the untagged **6.0.2** section, using the `*` bullets 6.x uses.
2. **`Base::makeAuthFailure()` keeps `null` and 6.x's `@phpstan-ignore`.** The 5.x branch passes `''` there to satisfy PHPStan; 6.x already solved the same warning with an annotation reasoning that core's `Login\Auth` passes `null` too and the `AuthResult` `@param` is too narrow. I kept 6.x's decision rather than overrule it in a backport, so that one line differs between branches. The new `WebServerSessionAuth` passes `''` since it is new code needing no annotation — say the word if you would rather both used the annotated `null`.
3. Everything else that still differs between this branch and `5.x-dev` in the touched files is pre-existing 6.x-only work — typed docblocks, other `@phpstan-ignore`s, dropped BC shims — which I left alone.

### Verification

- `plugins/LoginLdap/tests/Unit` — 196 tests, 426 assertions, OK
- PHPStan level 5 — no errors
- PHPCS `Matomo` standard — no errors on the changed production files

The integration tests need the LDAP fixture and were not run here; the local core is Matomo 5.14.0-alpha rather than Matomo 6, so CI is the real check.

### Still to port

#488 (#AS-730) is open against 5.x and touches `Base::synchronizeLdapUser()` in this same file. It will need its own backport once it lands.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [✔] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [✖] Documentation updated?