### PR TITLE
Port the exact LDAP instance identifier comparison to 6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # LoginLdap Changelog
 
+#### LoginLdap 6.0.2
+* Fixed the LDAP instance identifier comparison, so an access value naming a different Matomo instance is no longer applied to this one
+
 #### LoginLdap 6.0.1 - 2026-09-07
 * Fixed LDAP site access being denied when the instance name or a server separator contains a slash
 * Fixed a failed LDAP entry lookup being reported as no matching users, which surfaced as a failed login instead of the underlying LDAP error

--- a/LdapInterop/UserAccessAttributeParser.php
+++ b/LdapInterop/UserAccessAttributeParser.php
@@ -259,26 +259,23 @@ class UserAccessAttributeParser
      */
     protected function isInstanceIdForThisInstance($instanceId)
     {
-        if (empty($instanceId)) {
+        $instanceId = trim($instanceId);
+
+        if ($instanceId === '') {
             return true;
         }
 
         if ($this->thisPiwikInstanceName === null) {
             $result = $this->isUrlThisInstanceUrl($instanceId);
         } else {
-            preg_match("/\\b" . preg_quote($this->thisPiwikInstanceName, '/') . "\\b/", $instanceId, $matches);
+            $result = $instanceId === trim($this->thisPiwikInstanceName);
 
-            if (empty($matches)) {
-                $result = false;
-            } else {
-                if (strlen($matches[0]) != strlen($instanceId)) {
-                    $this->logger->debug(
-                        "UserAccessAttributeParser::{func}: Found extra characters in Piwik instance ID. Whole ID entry = {id}.",
-                        array('func' => __FUNCTION__, 'id' => $instanceId)
-                    );
-                }
-
-                $result = true;
+            if (!$result && $this->containsInstanceName($instanceId)) {
+                $this->logger->warning(
+                    "UserAccessAttributeParser::{func}: Ignoring instance ID '{id}': it contains the configured "
+                        . "instance name '{name}' but is not equal to it.",
+                    array('func' => __FUNCTION__, 'id' => $instanceId, 'name' => $this->thisPiwikInstanceName)
+                );
             }
         }
 
@@ -315,6 +312,21 @@ class UserAccessAttributeParser
         $delimiters = $this->serverIdsSeparator . $this->serverSpecificationDelimiter;
         $result = preg_split("/[" . preg_quote($delimiters, '/') . "]/", $attributeValue);
         return array_map('trim', $result);
+    }
+
+    /**
+     * Returns whether $instanceId contains the configured instance name as a word.
+     *
+     * Only used to log identifiers that earlier versions accepted for this instance.
+     *
+     * @param string $instanceId
+     * @return bool
+     */
+    private function containsInstanceName($instanceId)
+    {
+        $pattern = "/\\b" . preg_quote(trim($this->thisPiwikInstanceName), '/') . "\\b/";
+
+        return (bool) preg_match($pattern, $instanceId);
     }
 
     /**

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "LoginLdap",
-    "version": "6.0.1",
+    "version": "6.0.2",
     "description": "LDAP authentication and synchronization for Matomo.",
     "theme": false,
     "keywords": ["ldap", "login", "authentication", "active", "directory", "kerberos", "sso"],

--- a/tests/Unit/UserAccessAttributeParserTest.php
+++ b/tests/Unit/UserAccessAttributeParserTest.php
@@ -151,8 +151,8 @@ class UserAccessAttributeParserTest extends TestCase
     {
         $this->userAccessAttributeParser->setThisPiwikInstanceName('my/Piwik');
 
-        $this->assertTrue($this->userAccessAttributeParser->getSuperUserAccessFromSuperUserAttribute('otherPiwik,my/Piwik'));
-        $this->assertFalse($this->userAccessAttributeParser->getSuperUserAccessFromSuperUserAttribute('otherPiwik,thirdPiwik'));
+        $this->assertTrue($this->userAccessAttributeParser->getSuperUserAccessFromSuperUserAttribute('otherPiwik;my/Piwik'));
+        $this->assertFalse($this->userAccessAttributeParser->getSuperUserAccessFromSuperUserAttribute('otherPiwik;thirdPiwik'));
     }
 
     public function test_getSiteIdsFromAccessAttribute_ReturnsCorrectSiteIdList_WhenAllStringUsed()
@@ -189,8 +189,10 @@ class UserAccessAttributeParserTest extends TestCase
 
         $this->userAccessAttributeParser->setThisPiwikInstanceName("myPi|wik");
 
+        // only 'myPi|wik' is the configured instance ID. 'myPi|wik = view' and 'myPi | wik' are different
+        // identifiers and no longer contribute their sites
         $ids = $this->userAccessAttributeParser->getSiteIdsFromAccessAttribute(" ; ; myPi|wik : 1,2 ; myPi|wik = view:3,def; myPi | wik:4,5 ; ; ");
-        $this->assertEquals(array(1,2,3), $ids);
+        $this->assertEquals(array(1,2), $ids);
     }
 
     public function test_getSiteIdsFromAccessAttribute_ReturnsCorrectSiteIdList_WhenCustomDelimitersAreUsed()
@@ -256,6 +258,48 @@ class UserAccessAttributeParserTest extends TestCase
         $this->assertTrue($hasSuperUserAccess);
     }
 
+    /**
+     * @dataProvider getInstanceIdsThatAreNotThisInstance
+     */
+    public function test_getSuperUserAccessFromSuperUserAttribute_ReturnsFalse_IfInstanceIdOnlyContainsTheInstanceName($instanceId)
+    {
+        $this->userAccessAttributeParser->setThisPiwikInstanceName('matomo-prod');
+
+        $this->assertFalse($this->userAccessAttributeParser->getSuperUserAccessFromSuperUserAttribute($instanceId));
+    }
+
+    /**
+     * @dataProvider getInstanceIdsThatAreNotThisInstance
+     */
+    public function test_getSiteIdsFromAccessAttribute_ReturnsNoSites_IfInstanceIdOnlyContainsTheInstanceName($instanceId)
+    {
+        $this->userAccessAttributeParser->setThisPiwikInstanceName('matomo-prod');
+
+        $this->assertEquals(array(), $this->userAccessAttributeParser->getSiteIdsFromAccessAttribute($instanceId . ":1,2,3"));
+    }
+
+    public function getInstanceIdsThatAreNotThisInstance()
+    {
+        return array(
+            'suffix' => array('matomo-prod-eu'),
+            'prefix' => array('eu-matomo-prod'),
+            'surrounding text' => array('the matomo-prod instance'),
+            'unrelated' => array('matomo-stage'),
+
+            // '0' used to be treated as an unspecified instance ID, which matched every instance
+            'zero' => array('0'),
+        );
+    }
+
+    public function test_getSuperUserAccessFromSuperUserAttribute_ReturnsTrue_IfInstanceIdIsTheInstanceName()
+    {
+        $this->userAccessAttributeParser->setThisPiwikInstanceName('matomo-prod');
+
+        $this->assertTrue($this->userAccessAttributeParser->getSuperUserAccessFromSuperUserAttribute('matomo-prod'));
+        $this->assertTrue($this->userAccessAttributeParser->getSuperUserAccessFromSuperUserAttribute('  matomo-prod  '));
+        $this->assertTrue($this->userAccessAttributeParser->getSuperUserAccessFromSuperUserAttribute('matomo-prod-eu;matomo-prod'));
+    }
+
     public function test_getSuperUserAccessFromSuperUserAttribute_ReturnsFalse_IfInstanceNotInAttribute()
     {
         $this->userAccessAttributeParser->setThisPiwikInstanceName('myPiwik');
@@ -284,11 +328,13 @@ class UserAccessAttributeParserTest extends TestCase
     {
         $this->userAccessAttributeParser->setThisPiwikInstanceName('myPiwik');
 
+        // an instance ID is only this instance when it is exactly the configured name. Malformed values are
+        // no longer searched for the name, since that made one instance's grant apply to another.
         $hasSuperUserAccess = $this->userAccessAttributeParser->getSuperUserAccessFromSuperUserAttribute(" myPiwik = superuser ; whatever");
-        $this->assertTrue($hasSuperUserAccess);
+        $this->assertFalse($hasSuperUserAccess);
 
         $hasSuperUserAccess = $this->userAccessAttributeParser->getSuperUserAccessFromSuperUserAttribute("anothe; superuser = myPiwik ; whatever");
-        $this->assertTrue($hasSuperUserAccess);
+        $this->assertFalse($hasSuperUserAccess);
 
         $this->userAccessAttributeParser->setThisPiwikInstanceName(null);
         $this->userAccessAttributeParser->setServerSpecificationDelimiter('|');


### PR DESCRIPTION
Ports #483 to 6.x-dev. Refs #AS-715.

Cherry-pick of `048d590`.

### Change

`UserAccessAttributeParser::isInstanceIdForThisInstance()` searched the supplied instance ID for the configured `instance_name` as an unanchored `\b`-delimited word instead of comparing the two, so an instance named `matomo-prod` matched the identifier `matomo-prod-eu` and an access value naming a different Matomo instance was applied to this one. It now compares for equality, both trimmed, and logs a WARNING naming any identifier that would previously have matched.

`empty($instanceId)` became a trimmed empty-string check. `empty()` is also true for `"0"`, so a `superuser: 0` attribute value reached this method and returned `true`, granting Super User.

### Differences from the 5.x commit

Three, all forced by 6.x:

1. Version bumped to 6.0.2, changelog entry using the `*` bullets 6.x uses.
2. `trim($instanceId ?? '')` became `trim($instanceId)`. PHPStan, which 6.x runs in CI, reports the null coalesce as dead since every call site passes a string.
3. **`test_getSuperUserAccessFromSuperUserAttribute_ReturnsTrue_WhenInstanceNameContainsASlash` needed its fixture changed** — this test does not exist on 5.x, it came in with the 6.0.1 slash fix.

   It asserted that `'otherPiwik,my/Piwik'` grants Super User for instance `my/Piwik`. A comma is not one of the separators `getSuperUserInstancesFromAttribute()` splits on (`:` and `;`), so that value is a single instance ID and only matched through the substring search this PR removes. The fixture now uses `;`, an actual delimiter, which keeps the test's stated purpose — that a slash in the instance name does not break the pattern — without depending on substring recovery.

   The other slash regression test, `..._WhenSeparatorsContainASlash`, covers the `preg_split()` half of the 6.0.1 fix and is untouched and passing. The `preg_quote($name, '/')` half is preserved in the new `containsInstanceName()` helper.

### Overlap with #484

#484 also bumps `plugin.json` to 6.0.2 and adds a changelog heading. Whichever merges second needs a trivial rebase on those two files. There is no code overlap — this PR only touches `LdapInterop/UserAccessAttributeParser.php`.

### Verification

- `plugins/LoginLdap/tests/Unit` — 149 tests, 320 assertions, OK
- PHPStan level 5 — no errors
- PHPCS `Matomo` standard — no errors

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [✔] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [✖] Documentation updated?