### PR TITLE
Uses the same login comparison everywhere

### DIFF
--- a/Auth/Base.php
+++ b/Auth/Base.php
@@ -289,7 +289,7 @@ abstract class Base implements Auth
             if (!empty($this->login)) {
                 $user = $this->usersModel->getUser($this->login);
 
-                if (!empty($user) && !$this->isSameLogin($this->login, $user['login'])) {
+                if (!empty($user) && !UserIdentity::isSameLogin($this->login, $user['login'])) {
                     $this->logger->warning(
                         "Auth\\Base::{func}: refusing to authenticate '{assertedLogin}': it resolves to the "
                             . "existing Matomo user '{storedLogin}', which is a different login.",
@@ -315,18 +315,6 @@ abstract class Base implements Auth
             }
         }
         return $this->userForLogin;
-    }
-
-    /**
-     * Returns whether the asserted login and the login of the user row it resolved to identify the same user.
-     *
-     * @param string $assertedLogin
-     * @param string $storedLogin
-     * @return bool
-     */
-    protected function isSameLogin(string $assertedLogin, string $storedLogin): bool
-    {
-        return UserIdentity::isSameLogin($assertedLogin, $storedLogin);
     }
 
     protected function tryFallbackAuth($onlySuperUsers = true, ?Auth $auth = null)
@@ -394,7 +382,7 @@ abstract class Base implements Auth
 
     protected function makeAuthFailure()
     {
-        return new AuthResult(AuthResult::FAILURE, $this->login, null);
+        return new AuthResult(AuthResult::FAILURE, $this->login, '');
     }
 
     protected function authenticateByLdap()

--- a/Auth/Base.php
+++ b/Auth/Base.php
@@ -290,6 +290,16 @@ abstract class Base implements Auth
                 $user = $this->usersModel->getUser($this->login);
 
                 if (!empty($user) && !$this->isSameLogin($this->login, $user['login'])) {
+                    $this->logger->warning(
+                        "Auth\\Base::{func}: refusing to authenticate '{assertedLogin}': it resolves to the "
+                            . "existing Matomo user '{storedLogin}', which is a different login.",
+                        array(
+                            'func' => __FUNCTION__,
+                            'assertedLogin' => $this->login,
+                            'storedLogin' => $user['login'],
+                        )
+                    );
+
                     throw new Exception(sprintf(
                         "Refusing to authenticate: asserted login '%s' resolved to the different existing user '%s'.",
                         $this->login,
@@ -309,9 +319,6 @@ abstract class Base implements Auth
 
     /**
      * Returns whether the asserted login and the login of the user row it resolved to identify the same user.
-     *
-     * Implementations that verify no credential against the returned row have to override this and require an
-     * exact match.
      *
      * @param string $assertedLogin
      * @param string $storedLogin

--- a/Auth/WebServerAuth.php
+++ b/Auth/WebServerAuth.php
@@ -152,8 +152,11 @@ class WebServerAuth extends Base
     }
 
     /**
-     * Returns the login the web server authenticated for this request, normalized the way
-     * {@link self::authenticate()} normalizes it, or null when the web server authenticated nobody.
+     * Returns the login the web server authenticated for this request, or null when it authenticated nobody.
+     *
+     * Trimmed, so that the login this authenticates and the login {@link WebServerSessionAuth} compares the
+     * session against are the same value. A REMOTE_USER of "  ", or one that strips to nothing such as
+     * "SHIELD\\", names nobody and is reported as such.
      *
      * @return string|null
      */
@@ -166,10 +169,12 @@ class WebServerAuth extends Base
         }
 
         if (Config::getStripDomainFromWebAuth()) {
-            return preg_replace('/(.*?\\\\)|(@.*)/', '', $webServerAuthUser);
+            $webServerAuthUser = preg_replace('/(.*?\\\\)|(@.*)/', '', $webServerAuthUser);
         }
 
-        return $webServerAuthUser;
+        $webServerAuthUser = trim($webServerAuthUser);
+
+        return $webServerAuthUser === '' ? null : $webServerAuthUser;
     }
 
     public static function isCurrentRequestWebServerAuthenticated(): bool

--- a/Auth/WebServerAuth.php
+++ b/Auth/WebServerAuth.php
@@ -154,9 +154,13 @@ class WebServerAuth extends Base
     /**
      * Returns the login the web server authenticated for this request, or null when it authenticated nobody.
      *
-     * Trimmed, so that the login this authenticates and the login {@link WebServerSessionAuth} compares the
-     * session against are the same value. A REMOTE_USER of "  ", or one that strips to nothing such as
-     * "SHIELD\\", names nobody and is reported as such.
+     * The single answer to "who does the web server say this is", so that authentication, the session guard
+     * and {@link self::isCurrentRequestWebServerAuthenticated()} cannot disagree about it.
+     *
+     * The value is returned as the web server gave it. Trimming it here would let "ironman " authenticate as
+     * "ironman", which is a row the login column's collation returns for it and which the login comparison
+     * exists to refuse. Trimming decides only whether anybody was asserted at all, so that a REMOTE_USER of
+     * "  ", or one that strips to nothing such as "SHIELD\\", names nobody rather than the empty login.
      *
      * @return string|null
      */
@@ -172,15 +176,23 @@ class WebServerAuth extends Base
             $webServerAuthUser = preg_replace('/(.*?\\\\)|(@.*)/', '', $webServerAuthUser);
         }
 
-        $webServerAuthUser = trim($webServerAuthUser);
-
-        return $webServerAuthUser === '' ? null : $webServerAuthUser;
+        return trim($webServerAuthUser) === '' ? null : $webServerAuthUser;
     }
 
+    /**
+     * Returns whether the web server authenticated somebody for this request.
+     *
+     * Callers use this to skip Matomo's own password confirmation, so it has to agree with
+     * {@link self::getAssertedLogin()}: an assertion naming nobody authenticates nobody, and must not skip
+     * anything.
+     *
+     * @return bool
+     */
     public static function isCurrentRequestWebServerAuthenticated(): bool
     {
         $auth = StaticContainer::get('Piwik\Auth');
-        return $auth instanceof WebServerAuth && !empty($_SERVER['REMOTE_USER']);
+
+        return $auth instanceof WebServerAuth && self::getAssertedLogin() !== null;
     }
 
     private function synchronizeLoggedInUser()

--- a/Auth/WebServerAuth.php
+++ b/Auth/WebServerAuth.php
@@ -17,7 +17,6 @@ use Piwik\Plugins\LoginLdap\Config;
 use Piwik\Plugins\LoginLdap\Ldap\Exceptions\ConnectionException;
 use Piwik\Plugins\LoginLdap\LdapInterop\UserSynchronizer;
 use Piwik\Plugins\LoginLdap\Model\LdapUsers;
-use Piwik\Plugins\LoginLdap\UserIdentity;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 use Piwik\Plugins\UsersManager\Model as UserModel;
 use Piwik\Session;
@@ -177,19 +176,6 @@ class WebServerAuth extends Base
     {
         $auth = StaticContainer::get('Piwik\Auth');
         return $auth instanceof WebServerAuth && !empty($_SERVER['REMOTE_USER']);
-    }
-
-    /**
-     * No password, password hash or token auth is verified against the row the asserted login resolves to, so
-     * unlike the other auth implementations this one requires the stored login to match it exactly.
-     *
-     * @param string $assertedLogin
-     * @param string $storedLogin
-     * @return bool
-     */
-    protected function isSameLogin(string $assertedLogin, string $storedLogin): bool
-    {
-        return UserIdentity::isSameLoginExact($assertedLogin, $storedLogin);
     }
 
     private function synchronizeLoggedInUser()

--- a/Auth/WebServerSessionAuth.php
+++ b/Auth/WebServerSessionAuth.php
@@ -91,9 +91,9 @@ class WebServerSessionAuth extends SessionAuth
         $assertedLogin = WebServerAuth::getAssertedLogin();
 
         // an absent REMOTE_USER is not a mismatch: setups that require web server authentication on only some
-        // paths would otherwise log people out at random. Neither is one that strips to nothing, which
-        // WebServerAuth cannot authenticate anybody with either.
-        if ($assertedLogin === null || trim($assertedLogin) === '') {
+        // paths would otherwise log people out at random. getAssertedLogin() also reports one that names
+        // nobody as absent, so this and WebServerAuth agree on every value.
+        if ($assertedLogin === null) {
             return null;
         }
 
@@ -114,8 +114,8 @@ class WebServerSessionAuth extends SessionAuth
      */
     private function endSession(): void
     {
-        // not gated on Session::isSessionStarted(): that flag stays false when Session::start() returned early
-        // because a session was already active or headers were sent, and $_SESSION is populated regardless
+        // not gated on Session::isSessionStarted(): Session::start() returns before setting that flag when a
+        // session is already active, so the flag can be false while $_SESSION holds the previous user's data
         $_SESSION = array();
 
         $this->destroyCurrentSession(new SessionFingerprint());

--- a/Auth/WebServerSessionAuth.php
+++ b/Auth/WebServerSessionAuth.php
@@ -14,7 +14,6 @@ use Piwik\Container\StaticContainer;
 use Piwik\Log\LoggerInterface;
 use Piwik\Plugins\LoginLdap\Config;
 use Piwik\Plugins\LoginLdap\UserIdentity;
-use Piwik\Session;
 use Piwik\Session\SessionAuth;
 use Piwik\Session\SessionFingerprint;
 
@@ -72,7 +71,7 @@ class WebServerSessionAuth extends SessionAuth
 
         $this->endSession();
 
-        return new AuthResult(AuthResult::FAILURE, null, null);
+        return new AuthResult(AuthResult::FAILURE, '', '');
     }
 
     /**
@@ -92,14 +91,15 @@ class WebServerSessionAuth extends SessionAuth
         $assertedLogin = WebServerAuth::getAssertedLogin();
 
         // an absent REMOTE_USER is not a mismatch: setups that require web server authentication on only some
-        // paths would otherwise log people out at random
-        if ($assertedLogin === null) {
+        // paths would otherwise log people out at random. Neither is one that strips to nothing, which
+        // WebServerAuth cannot authenticate anybody with either.
+        if ($assertedLogin === null || trim($assertedLogin) === '') {
             return null;
         }
 
         $sessionUser = (new SessionFingerprint())->getUser();
 
-        if (empty($sessionUser) || UserIdentity::isSameLoginExact($assertedLogin, $sessionUser)) {
+        if (empty($sessionUser) || UserIdentity::isSameLogin($assertedLogin, $sessionUser)) {
             return null;
         }
 
@@ -114,9 +114,9 @@ class WebServerSessionAuth extends SessionAuth
      */
     private function endSession(): void
     {
-        if (Session::isSessionStarted()) {
-            $_SESSION = array();
-        }
+        // not gated on Session::isSessionStarted(): that flag stays false when Session::start() returned early
+        // because a session was already active or headers were sent, and $_SESSION is populated regardless
+        $_SESSION = array();
 
         $this->destroyCurrentSession(new SessionFingerprint());
     }

--- a/Auth/WebServerSessionAuth.php
+++ b/Auth/WebServerSessionAuth.php
@@ -93,6 +93,9 @@ class WebServerSessionAuth extends SessionAuth
         // an absent REMOTE_USER is not a mismatch: setups that require web server authentication on only some
         // paths would otherwise log people out at random. getAssertedLogin() also reports one that names
         // nobody as absent, so this and WebServerAuth agree on every value.
+        //
+        // A REMOTE_USER that only differs from the session's user by surrounding whitespace is a mismatch and
+        // ends the session, as it would be for any other login WebServerAuth refuses to authenticate.
         if ($assertedLogin === null) {
             return null;
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 #### LoginLdap 5.2.7- 2026-09-14
 - Fixed the LDAP instance identifier comparison, so an access value naming a different Matomo instance is no longer applied to this one
 - Fixed the login comparison so that logins the database collation treats as equal, but which are different users, are no longer accepted
-- Added an exact login match requirement when authenticating through the web server
 - Added termination of a Matomo session when the web server starts authenticating a different user
 
 #### LoginLdap 5.2.6 - 2026-08-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # LoginLdap Changelog
 
-#### LoginLdap 5.2.7- 2026-09-14
+#### LoginLdap 5.2.7 - 2026-09-14
 - Fixed the LDAP instance identifier comparison, so an access value naming a different Matomo instance is no longer applied to this one
 - Fixed the login comparison so that logins the database collation treats as equal, but which are different users, are no longer accepted
 - Added termination of a Matomo session when the web server starts authenticating a different user

--- a/LoginLdap.php
+++ b/LoginLdap.php
@@ -275,11 +275,10 @@ class LoginLdap extends \Piwik\Plugin
             return;
         }
 
-        // Only a web-server-authenticated request bypasses the password. When REMOTE_USER is
-        // absent, WebServerAuth delegates to its password-validating fallback, so token
-        // creation stays safe and must remain allowed.
-        $auth = StaticContainer::get('Piwik\Auth');
-        if ($auth instanceof WebServerAuth && !empty($_SERVER['REMOTE_USER'])) {
+        // Only a web-server-authenticated request bypasses the password. When the web server authenticated
+        // nobody, WebServerAuth delegates to its password-validating fallback, so token creation stays safe
+        // and must remain allowed.
+        if (WebServerAuth::isCurrentRequestWebServerAuthenticated()) {
             throw new Exception(Piwik::translate('LoginLdap_CreateAppSpecificTokenAuthBlocked'));
         }
     }

--- a/UserIdentity.php
+++ b/UserIdentity.php
@@ -33,21 +33,6 @@ class UserIdentity
     }
 
     /**
-     * Returns true if the asserted login and the stored login are byte for byte identical.
-     *
-     * Used where the login is the only thing binding a request to an account, so that not even ASCII case
-     * differences are tolerated.
-     *
-     * @param string $assertedLogin The login the web server asserted.
-     * @param string $storedLogin The login of the user row, or of the session, it was matched against.
-     * @return bool
-     */
-    public static function isSameLoginExact(string $assertedLogin, string $storedLogin): bool
-    {
-        return $assertedLogin === $storedLogin;
-    }
-
-    /**
      * Lowercases the ASCII letters in $value and leaves every other byte untouched.
      *
      * strtolower() is not used since it is locale aware on PHP versions before 8.2 and can fold bytes outside

--- a/tests/Integration/WebServerAuthTest.php
+++ b/tests/Integration/WebServerAuthTest.php
@@ -91,9 +91,37 @@ class WebServerAuthTest extends LdapIntegrationTest
     public function getLoginsResolvingToTheSuperUser()
     {
         return array(
-            'ascii case difference' => array(ucfirst(self::TEST_SUPERUSER_LOGIN)),
             'accented character' => array(substr(self::TEST_SUPERUSER_LOGIN, 0, -1) . "\xc3\xa1"),
         );
+    }
+
+    public function test_WebServerAuth_Works_IfAssertedLoginDiffersFromTheStoredOneOnlyByAsciiCase()
+    {
+        Config::getInstance()->LoginLdap['use_webserver_auth'] = 1;
+
+        $_SERVER['REMOTE_USER'] = strtoupper(self::TEST_SUPERUSER_LOGIN);
+
+        $ldapAuth = WebServerAuth::makeConfigured();
+        $authResult = $ldapAuth->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS_SUPERUSER_AUTH_CODE, $authResult->getCode());
+        $this->assertEquals(self::TEST_SUPERUSER_LOGIN, $authResult->getIdentity());
+    }
+
+    public function test_WebServerAuth_Works_OnEveryRequest_IfTheUserIsProvisionedFromADifferentlyCasedLogin()
+    {
+        Config::getInstance()->LoginLdap['use_webserver_auth'] = 1;
+
+        // the Matomo user does not exist yet, so it is created from the LDAP entry's own casing. Every later
+        // request asserts the login the web server has, which must keep resolving to that user.
+        $_SERVER['REMOTE_USER'] = strtoupper(self::TEST_LOGIN);
+
+        foreach (array('first', 'second') as $request) {
+            $authResult = WebServerAuth::makeConfigured()->authenticate();
+
+            $this->assertEquals(AuthResult::SUCCESS, $authResult->getCode(), "failed on the {$request} request");
+            $this->assertEquals(self::TEST_LOGIN, $authResult->getIdentity());
+        }
     }
 
     public function test_WebServerAuth_Fails_IfUserIsNotPartOfRequiredGroup()

--- a/tests/Unit/WebServerAuthAssertionTest.php
+++ b/tests/Unit/WebServerAuthAssertionTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\LoginLdap\tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\Config;
+use Piwik\Container\StaticContainer;
+use Piwik\Log\LoggerInterface;
+use Piwik\Plugins\LoginLdap\Auth\WebServerAuth;
+
+/**
+ * @group LoginLdap
+ * @group LoginLdap_Unit
+ * @group LoginLdap_WebServerAuthAssertionTest
+ */
+class WebServerAuthAssertionTest extends TestCase
+{
+    /**
+     * @var array
+     */
+    private $configBackup;
+
+    /**
+     * @var mixed
+     */
+    private $authBackup;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configBackup = Config::getInstance()->LoginLdap;
+        $this->authBackup = StaticContainer::get('Piwik\Auth');
+
+        Config::getInstance()->LoginLdap = array(
+            'use_webserver_auth' => 1,
+            'strip_domain_from_web_auth' => 1,
+        );
+
+        StaticContainer::getContainer()->set('Piwik\Auth', new WebServerAuth($this->createMock(LoggerInterface::class)));
+    }
+
+    public function tearDown(): void
+    {
+        unset($_SERVER['REMOTE_USER']);
+        StaticContainer::getContainer()->set('Piwik\Auth', $this->authBackup);
+        Config::getInstance()->LoginLdap = $this->configBackup;
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider getAssertionsNamingNobody
+     */
+    public function test_getAssertedLogin_ReturnsNull_IfTheAssertionNamesNobody($remoteUser)
+    {
+        $_SERVER['REMOTE_USER'] = $remoteUser;
+
+        $this->assertNull(WebServerAuth::getAssertedLogin());
+    }
+
+    /**
+     * Callers skip Matomo's password confirmation on the strength of this, so an assertion that authenticates
+     * nobody must not report the request as web server authenticated.
+     *
+     * @dataProvider getAssertionsNamingNobody
+     */
+    public function test_isCurrentRequestWebServerAuthenticated_IsFalse_IfTheAssertionNamesNobody($remoteUser)
+    {
+        $_SERVER['REMOTE_USER'] = $remoteUser;
+
+        $this->assertFalse(WebServerAuth::isCurrentRequestWebServerAuthenticated());
+    }
+
+    public function getAssertionsNamingNobody()
+    {
+        return array(
+            'absent' => array(null),
+            'empty' => array(''),
+            'whitespace only' => array('   '),
+            'domain only' => array('SHIELD\\'),
+            'at sign only' => array('@shield.org'),
+        );
+    }
+
+    /**
+     * @dataProvider getAssertionsNamingSomebody
+     */
+    public function test_getAssertedLogin_ReturnsTheLoginUntrimmed($expected, $remoteUser)
+    {
+        $_SERVER['REMOTE_USER'] = $remoteUser;
+
+        $this->assertSame($expected, WebServerAuth::getAssertedLogin());
+        $this->assertTrue(WebServerAuth::isCurrentRequestWebServerAuthenticated());
+    }
+
+    public function getAssertionsNamingSomebody()
+    {
+        return array(
+            'plain' => array('ironman', 'ironman'),
+            'domain stripped' => array('ironman', 'SHIELD\\ironman'),
+            'suffix stripped' => array('ironman', 'ironman@shield.org'),
+
+            // surrounding whitespace is part of the asserted identity, not noise to be cleaned up: the login
+            // column's collation returns 'ironman' for 'ironman ', and trimming would authenticate that user
+            'trailing space kept' => array('ironman ', 'ironman '),
+            'leading space kept' => array(' ironman', ' ironman'),
+        );
+    }
+}

--- a/tests/Unit/WebServerAuthLoginResolutionTest.php
+++ b/tests/Unit/WebServerAuthLoginResolutionTest.php
@@ -81,27 +81,6 @@ class WebServerAuthLoginResolutionTest extends TestCase
     }
 
     /**
-     * @dataProvider getLoginsWithSurroundingWhitespace
-     */
-    public function test_authenticate_Succeeds_IfTheAssertedLoginHasSurroundingWhitespace($remoteUser)
-    {
-        $_SERVER['REMOTE_USER'] = $remoteUser;
-
-        $result = $this->makeAuth($this->makeUserRow())->authenticate();
-
-        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
-        $this->assertEquals(self::LDAP_LOGIN, $result->getIdentity());
-    }
-
-    public function getLoginsWithSurroundingWhitespace()
-    {
-        return array(
-            'trailing' => array(self::LDAP_LOGIN . ' '),
-            'leading' => array(' ' . self::LDAP_LOGIN),
-        );
-    }
-
-    /**
      * @dataProvider getLoginsResolvingToADifferentUser
      */
     public function test_authenticate_Fails_IfAssertedLoginResolvesToADifferentUser($remoteUser)
@@ -120,6 +99,10 @@ class WebServerAuthLoginResolutionTest extends TestCase
             'accented character' => array("ironm\xc3\xa1n"),
             'kelvin sign' => array("\xe2\x84\xaaironman"),
             'a different user' => array('thanos'),
+
+            // PAD SPACE collations return the stored user for these, so they must not be trimmed into it
+            'trailing space' => array(self::LDAP_LOGIN . ' '),
+            'leading space' => array(' ' . self::LDAP_LOGIN),
         );
     }
 

--- a/tests/Unit/WebServerAuthLoginResolutionTest.php
+++ b/tests/Unit/WebServerAuthLoginResolutionTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\LoginLdap\tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\AuthResult;
+use Piwik\Config;
+use Piwik\Log\LoggerInterface;
+use Piwik\Plugins\LoginLdap\Auth\WebServerAuth;
+use Piwik\Plugins\LoginLdap\LdapInterop\UserSynchronizer;
+use Piwik\Plugins\LoginLdap\Model\LdapUsers;
+use Piwik\Plugins\UsersManager\Model as UserModel;
+
+/**
+ * @group LoginLdap
+ * @group LoginLdap_Unit
+ * @group LoginLdap_WebServerAuthLoginResolutionTest
+ */
+class WebServerAuthLoginResolutionTest extends TestCase
+{
+    private const LDAP_LOGIN = 'ironman';
+
+    /**
+     * @var array
+     */
+    private $configBackup;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configBackup = Config::getInstance()->LoginLdap;
+        Config::getInstance()->LoginLdap = array(
+            'use_webserver_auth' => 1,
+            'strip_domain_from_web_auth' => 0,
+        );
+    }
+
+    public function tearDown(): void
+    {
+        unset($_SERVER['REMOTE_USER']);
+        Config::getInstance()->LoginLdap = $this->configBackup;
+
+        parent::tearDown();
+    }
+
+    /**
+     * The Matomo user does not exist yet, so synchronization creates it from the LDAP entry's own casing.
+     * Every later request asserts whatever the web server has, which has to keep resolving to that user.
+     */
+    public function test_authenticate_Succeeds_OnEveryRequest_IfTheUserWasProvisionedFromADifferentlyCasedLogin()
+    {
+        $_SERVER['REMOTE_USER'] = strtoupper(self::LDAP_LOGIN);
+
+        $provisioning = $this->makeAuth($existingUser = array());
+        $this->assertEquals(AuthResult::SUCCESS, $provisioning->authenticate()->getCode());
+
+        $laterRequest = $this->makeAuth($this->makeUserRow());
+        $result = $laterRequest->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertEquals(self::LDAP_LOGIN, $result->getIdentity());
+    }
+
+    public function test_authenticate_Succeeds_IfAssertedLoginDiffersFromTheStoredOneOnlyByAsciiCase()
+    {
+        $_SERVER['REMOTE_USER'] = 'IronMan';
+
+        $result = $this->makeAuth($this->makeUserRow())->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertEquals(self::LDAP_LOGIN, $result->getIdentity());
+    }
+
+    /**
+     * @dataProvider getLoginsResolvingToADifferentUser
+     */
+    public function test_authenticate_Fails_IfAssertedLoginResolvesToADifferentUser($remoteUser)
+    {
+        $_SERVER['REMOTE_USER'] = $remoteUser;
+
+        $result = $this->makeAuth($this->makeUserRow())->authenticate();
+
+        $this->assertEquals(AuthResult::FAILURE, $result->getCode());
+    }
+
+    public function getLoginsResolvingToADifferentUser()
+    {
+        // the login column's collation returns the stored user for each of these, but they are not it
+        return array(
+            'accented character' => array("ironm\xc3\xa1n"),
+            'kelvin sign' => array("\xe2\x84\xaaironman"),
+            'trailing space' => array('ironman '),
+        );
+    }
+
+    private function makeUserRow()
+    {
+        return array('login' => self::LDAP_LOGIN, 'superuser_access' => 0, 'password' => 'whatever');
+    }
+
+    /**
+     * @param array $existingUser what UserModel::getUser() returns for the asserted login
+     */
+    private function makeAuth($existingUser)
+    {
+        $auth = new WebServerAuth($this->createMock(LoggerInterface::class));
+
+        $usersModel = $this->getMockBuilder(UserModel::class)
+                           ->onlyMethods(array('getUser', 'generateRandomTokenAuth'))
+                           ->getMock();
+        $usersModel->method('getUser')->willReturn($existingUser);
+        $usersModel->method('generateRandomTokenAuth')->willReturn('atoken');
+        $auth->setUsersModel($usersModel);
+
+        $ldapUsers = $this->getMockBuilder(LdapUsers::class)
+                          ->disableOriginalConstructor()
+                          ->onlyMethods(array('getUser'))
+                          ->getMock();
+        $ldapUsers->method('getUser')->willReturn(array('uid' => array(self::LDAP_LOGIN)));
+        $auth->setLdapUsers($ldapUsers);
+
+        $synchronizer = $this->getMockBuilder(UserSynchronizer::class)
+                             ->onlyMethods(array('synchronizeLdapUser', 'synchronizePiwikAccessFromLdap'))
+                             ->getMock();
+        $synchronizer->method('synchronizeLdapUser')->willReturn($this->makeUserRow());
+        $auth->setUserSynchronizer($synchronizer);
+
+        return $auth;
+    }
+}

--- a/tests/Unit/WebServerAuthLoginResolutionTest.php
+++ b/tests/Unit/WebServerAuthLoginResolutionTest.php
@@ -81,6 +81,27 @@ class WebServerAuthLoginResolutionTest extends TestCase
     }
 
     /**
+     * @dataProvider getLoginsWithSurroundingWhitespace
+     */
+    public function test_authenticate_Succeeds_IfTheAssertedLoginHasSurroundingWhitespace($remoteUser)
+    {
+        $_SERVER['REMOTE_USER'] = $remoteUser;
+
+        $result = $this->makeAuth($this->makeUserRow())->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertEquals(self::LDAP_LOGIN, $result->getIdentity());
+    }
+
+    public function getLoginsWithSurroundingWhitespace()
+    {
+        return array(
+            'trailing' => array(self::LDAP_LOGIN . ' '),
+            'leading' => array(' ' . self::LDAP_LOGIN),
+        );
+    }
+
+    /**
      * @dataProvider getLoginsResolvingToADifferentUser
      */
     public function test_authenticate_Fails_IfAssertedLoginResolvesToADifferentUser($remoteUser)
@@ -98,7 +119,7 @@ class WebServerAuthLoginResolutionTest extends TestCase
         return array(
             'accented character' => array("ironm\xc3\xa1n"),
             'kelvin sign' => array("\xe2\x84\xaaironman"),
-            'trailing space' => array('ironman '),
+            'a different user' => array('thanos'),
         );
     }
 

--- a/tests/Unit/WebServerSessionAuthTest.php
+++ b/tests/Unit/WebServerSessionAuthTest.php
@@ -26,6 +26,7 @@ use Piwik\Session\SessionFingerprint;
 class WebServerSessionAuthTest extends TestCase
 {
     private const SESSION_USER = 'karen';
+    private const OTHER_SESSION_NAMESPACE = 'Piwik_Login';
 
     /**
      * @var array
@@ -49,7 +50,12 @@ class WebServerSessionAuthTest extends TestCase
             'strip_domain_from_web_auth' => 0,
         );
 
-        $_SESSION = array(SessionFingerprint::USER_NAME_SESSION_VAR_NAME => self::SESSION_USER);
+        $_SESSION = array(
+            SessionFingerprint::USER_NAME_SESSION_VAR_NAME => self::SESSION_USER,
+            // a namespace belonging to the session's user that SessionFingerprint::clear() does not touch,
+            // so that the tests can tell the wipe in endSession() from clear() emptying the array by itself
+            self::OTHER_SESSION_NAMESPACE => array('redirectParams' => 'whatever'),
+        );
     }
 
     public function tearDown(): void
@@ -86,6 +92,7 @@ class WebServerSessionAuthTest extends TestCase
     public function test_authenticate_UsesTheSessionAuth_IfThereIsNoSessionYet()
     {
         $_SESSION = array();
+
         $_SERVER['REMOTE_USER'] = 'someoneelse';
 
         $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
@@ -164,7 +171,18 @@ class WebServerSessionAuthTest extends TestCase
         return array(
             'domain only' => array('SHIELD\\'),
             'at sign only' => array('@shield.org'),
+            'whitespace only' => array('   '),
         );
+    }
+
+    public function test_authenticate_UsesTheSessionAuth_IfTheAssertedLoginHasSurroundingWhitespace()
+    {
+        $_SERVER['REMOTE_USER'] = ' ' . self::SESSION_USER . ' ';
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertSessionWasKept();
     }
 
     public function test_authenticate_UsesTheSessionAuth_IfOnlyTheStrippedDomainDiffers()
@@ -195,11 +213,13 @@ class WebServerSessionAuthTest extends TestCase
     private function assertSessionWasKept()
     {
         $this->assertEquals(self::SESSION_USER, (new SessionFingerprint())->getUser());
+        $this->assertArrayHasKey(self::OTHER_SESSION_NAMESPACE, $_SESSION);
     }
 
     private function assertSessionWasEnded()
     {
         $this->assertNull((new SessionFingerprint())->getUser());
+        $this->assertArrayNotHasKey(self::OTHER_SESSION_NAMESPACE, $_SESSION);
         $this->assertEquals(array(), $_SESSION);
     }
 

--- a/tests/Unit/WebServerSessionAuthTest.php
+++ b/tests/Unit/WebServerSessionAuthTest.php
@@ -135,6 +135,9 @@ class WebServerSessionAuthTest extends TestCase
             // one WebServerAuth would authenticate
             'accented character' => array("\xc3\xa1aren"),
             'kelvin sign' => array("\xe2\x84\xaaaren"),
+
+            // not trimmed into the session's user, for the same reason WebServerAuth will not authenticate it
+            'surrounding whitespace' => array(' ' . self::SESSION_USER . ' '),
         );
     }
 
@@ -173,16 +176,6 @@ class WebServerSessionAuthTest extends TestCase
             'at sign only' => array('@shield.org'),
             'whitespace only' => array('   '),
         );
-    }
-
-    public function test_authenticate_UsesTheSessionAuth_IfTheAssertedLoginHasSurroundingWhitespace()
-    {
-        $_SERVER['REMOTE_USER'] = ' ' . self::SESSION_USER . ' ';
-
-        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
-
-        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
-        $this->assertSessionWasKept();
     }
 
     public function test_authenticate_UsesTheSessionAuth_IfOnlyTheStrippedDomainDiffers()

--- a/tests/Unit/WebServerSessionAuthTest.php
+++ b/tests/Unit/WebServerSessionAuthTest.php
@@ -115,7 +115,7 @@ class WebServerSessionAuthTest extends TestCase
         $result = $this->makeAuth($this->makeWrappedAuth($isCalled = false))->authenticate();
 
         $this->assertEquals(AuthResult::FAILURE, $result->getCode());
-        $this->assertNull($result->getIdentity());
+        $this->assertSame('', $result->getIdentity());
         $this->assertSessionWasEnded();
     }
 
@@ -124,10 +124,46 @@ class WebServerSessionAuthTest extends TestCase
         return array(
             'a different user' => array('bob'),
 
-            // the session guard uses the same exact comparison WebServerAuth uses
-            'ascii case difference' => array('Karen'),
+            // the session guard uses the same comparison WebServerAuth uses, so a session it keeps is always
+            // one WebServerAuth would authenticate
             'accented character' => array("\xc3\xa1aren"),
             'kelvin sign' => array("\xe2\x84\xaaaren"),
+        );
+    }
+
+    public function test_authenticate_UsesTheSessionAuth_IfTheAssertedLoginDiffersOnlyByAsciiCase()
+    {
+        $_SERVER['REMOTE_USER'] = ucfirst(self::SESSION_USER);
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertSessionWasKept();
+    }
+
+    /**
+     * @dataProvider getRemoteUsersThatStripToNothing
+     */
+    public function test_authenticate_UsesTheSessionAuth_IfTheAssertedLoginStripsToNothing($remoteUser)
+    {
+        Config::getInstance()->LoginLdap = array(
+            'use_webserver_auth' => 1,
+            'strip_domain_from_web_auth' => 1,
+        );
+
+        $_SERVER['REMOTE_USER'] = $remoteUser;
+
+        $result = $this->makeAuth($this->makeWrappedAuth($isCalled = true))->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertSessionWasKept();
+    }
+
+    public function getRemoteUsersThatStripToNothing()
+    {
+        return array(
+            'domain only' => array('SHIELD\\'),
+            'at sign only' => array('@shield.org'),
         );
     }
 


### PR DESCRIPTION
Addresses review feedback on #484, applied to 5.x first since 5.2.7 is not tagged yet. #484 will be re-ported from this. Refs #AS-689.

### The exact match is removed

`WebServerAuth` and the session guard used `UserIdentity::isSameLoginExact()`. The reasoning was that upstream authenticators treat logins differing in ASCII case as separate principals, so `REMOTE_USER=karen` should not authenticate as stored superuser `Karen`.

That defence is worth less than it costs. `matomo_user.login` is a primary key under a case- and accent-insensitive collation, so `karen` and `Karen` cannot both exist as Matomo users. For the attack to be possible, the upstream would have to treat them as different people while the directory this plugin authenticates against treats them as one entry — LDAP `uid` matching is case-insensitive, so it does not. The ASCII fold still refuses everything the collation folds beyond ASCII case, which is the reported issue: a Kelvin-sign identity resolving to an existing local superuser is rejected.

Against that, the exact match broke two things:

- **Existing installs locked out on upgrade.** Where the stored login is cased differently from `REMOTE_USER`, the first request after the update ended the session *and* refused the login, superusers included, with no in-app recovery.
- **New users were provisioned and then locked out.** `Base::synchronizeLdapUser()` assigns `$this->userForLogin` directly, so after synchronization `getUserForLogin()` returns the cached row without re-comparing and the first request succeeded. Every request after that resolved the now-existing row and was refused.

Both call sites now use `UserIdentity::isSameLogin()`, and `isSameLoginExact()` is gone.

### Also fixed

- A `REMOTE_USER` that strips to the empty string (`SHIELD\`, `@shield.org`) destroyed a live session: `getAssertedLogin()` returns `''` and the guard only tested `=== null`. Such a value is now treated as no assertion, as it was before this work.
- `endSession()` wiped `$_SESSION` only when `Session::isSessionStarted()`. That flag stays false whenever `Session::start()` returned early — a session already active, or headers sent — while `$_SESSION` is populated regardless, so `destroyCurrentSession()` carried the previous user's namespaces across. The wipe is now unconditional.
- The refusal reached the log only through `logger->debug()`, so a locked-out user left no trace at the default level while `UserSynchronizer` logs the equivalent at `warning`. It now logs at `warning` too.
- `new AuthResult(AuthResult::FAILURE, null, null)` passes `''` for both, which `AuthResult` documents as `string`. This is the change #484 already carries; making it here keeps the branches identical.

### Tests

`tests/Unit/WebServerAuthLoginResolutionTest.php` is new and covers the two lockouts directly — I confirmed both of its positive cases fail when the exact match is reinstated and pass with the fold, and that the three collation-collision cases (accent, Kelvin sign, trailing space) are refused either way.

The integration test's `ascii case difference` row moved from the refusal provider to its own passing test, and a provisioning test was added there too. Neither integration test could be run locally — the LDAP fixture is unavailable here, and five pre-existing tests in that file fail for the same reason on an untouched `5.x-dev`.

Plugin unit suite: 160 tests, 364 assertions, OK. PHPCS clean on the changed production files. PHPStan reports nothing in the changed files; the 20 errors it reports across 9 other files are pre-existing on `5.x-dev`, which has a `phpstan.neon` but no PHPStan workflow.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [✔] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [✖] Documentation updated?