### PR TITLE
Builds the login result from the synchronized access

### DIFF
--- a/Auth/Base.php
+++ b/Auth/Base.php
@@ -367,6 +367,10 @@ abstract class Base implements Auth
         $syncedLogin = !empty($this->userForLogin['login']) ? $this->userForLogin['login'] : $this->login;
 
         $this->userSynchronizer->synchronizePiwikAccessFromLdap($syncedLogin, $ldapUser);
+
+        // read the row back: access synchronization has just applied the access LDAP grants now, which can
+        // differ from what the row held when it was returned above
+        $this->userForLogin = $this->usersModel->getUser($syncedLogin);
     }
 
     protected function makeSuccessLogin($userInfo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed the LDAP instance identifier comparison, so an access value naming a different Matomo instance is no longer applied to this one
 - Fixed the login comparison so that logins the database collation treats as equal, but which are different users, are no longer accepted
 - Added termination of a Matomo session when the web server starts authenticating a different user
+- Fixed the login result being built from the user's access as it was before LDAP access synchronization ran
 
 #### LoginLdap 5.2.6 - 2026-08-24
 - Added strict check for TLS if enabled

--- a/tests/Integration/LdapUserSynchronizationTest.php
+++ b/tests/Integration/LdapUserSynchronizationTest.php
@@ -11,6 +11,7 @@
 namespace Piwik\Plugins\LoginLdap\tests\Integration;
 
 use Piwik\Access;
+use Piwik\AuthResult;
 use Piwik\Auth\Password;
 use Piwik\Config;
 use Piwik\Db;
@@ -170,7 +171,11 @@ class LdapUserSynchronizationTest extends LdapIntegrationTest
     {
         $this->enableAccessSynchronization();
 
-        $this->authenticateViaLdap(self::TEST_SUPERUSER_LOGIN, self::TEST_SUPERUSER_PASS);
+        $this->authenticateViaLdap(
+            self::TEST_SUPERUSER_LOGIN,
+            self::TEST_SUPERUSER_PASS,
+            AuthResult::SUCCESS_SUPERUSER_AUTH_CODE
+        );
 
         $superusers = $this->getSuperUsers();
         $this->assertEquals(array(self::TEST_SUPERUSER_LOGIN), $superusers);
@@ -227,7 +232,7 @@ class LdapUserSynchronizationTest extends LdapIntegrationTest
         Config::getInstance()->LoginLdap['instance_name'] = 'myPiwik';
         $this->enableAccessSynchronization();
 
-        $this->authenticateViaLdap('thor', 'bilgesnipe');
+        $this->authenticateViaLdap('thor', 'bilgesnipe', AuthResult::SUCCESS_SUPERUSER_AUTH_CODE);
 
         $superusers = $this->getSuperUsers();
         $this->assertEquals(array('thor'), $superusers);
@@ -256,7 +261,7 @@ class LdapUserSynchronizationTest extends LdapIntegrationTest
         $this->setPiwikInstanceUrl('http://localhost/');
         $this->enableAccessSynchronization();
 
-        $this->authenticateViaLdap('thor', 'bilgesnipe');
+        $this->authenticateViaLdap('thor', 'bilgesnipe', AuthResult::SUCCESS_SUPERUSER_AUTH_CODE);
 
         $superusers = $this->getSuperUsers();
         $this->assertEquals(array('thor'), $superusers);
@@ -320,14 +325,23 @@ class LdapUserSynchronizationTest extends LdapIntegrationTest
         return $result;
     }
 
-    private function authenticateViaLdap($login = self::TEST_LOGIN, $pass = self::TEST_PASS)
-    {
+    /**
+     * @param string $login
+     * @param string $pass
+     * @param int $expectedCode the result code for the access synchronization leaves the user with, which is
+     *                          the superuser code when the LDAP entry grants superuser access
+     */
+    private function authenticateViaLdap(
+        $login = self::TEST_LOGIN,
+        $pass = self::TEST_PASS,
+        $expectedCode = AuthResult::SUCCESS
+    ) {
         $ldapAuth = LdapAuth::makeConfigured();
         $ldapAuth->setLogin($login);
         $ldapAuth->setPassword($pass);
         $authResult = $ldapAuth->authenticate();
 
-        $this->assertEquals(1, $authResult->getCode());
+        $this->assertEquals($expectedCode, $authResult->getCode());
 
         return $authResult;
     }

--- a/tests/Unit/WebServerAuthAccessSyncTest.php
+++ b/tests/Unit/WebServerAuthAccessSyncTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\LoginLdap\tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\AuthResult;
+use Piwik\Config;
+use Piwik\Log\LoggerInterface;
+use Piwik\Plugins\LoginLdap\Auth\WebServerAuth;
+use Piwik\Plugins\LoginLdap\LdapInterop\UserSynchronizer;
+use Piwik\Plugins\LoginLdap\Model\LdapUsers;
+use Piwik\Plugins\UsersManager\Model as UserModel;
+
+/**
+ * @group LoginLdap
+ * @group LoginLdap_Unit
+ * @group LoginLdap_WebServerAuthAccessSyncTest
+ */
+class WebServerAuthAccessSyncTest extends TestCase
+{
+    private const LOGIN = 'ironman';
+
+    /**
+     * The user's superuser_access column, as access synchronization leaves it.
+     *
+     * @var int
+     */
+    private $superUserAccessInDb = 1;
+
+    /**
+     * @var array
+     */
+    private $configBackup;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configBackup = Config::getInstance()->LoginLdap;
+        Config::getInstance()->LoginLdap = array(
+            'use_webserver_auth' => 1,
+            'strip_domain_from_web_auth' => 0,
+        );
+
+        $_SERVER['REMOTE_USER'] = self::LOGIN;
+    }
+
+    public function tearDown(): void
+    {
+        unset($_SERVER['REMOTE_USER']);
+        Config::getInstance()->LoginLdap = $this->configBackup;
+
+        parent::tearDown();
+    }
+
+    /**
+     * Access synchronization runs after the user row has been read, so the result has to be built from the
+     * row as synchronization left it rather than the one read before it.
+     */
+    public function test_authenticate_IsNotSuperUser_IfAccessSynchronizationJustRevokedIt()
+    {
+        $auth = $this->makeAuth($accessSynchronizationLeaves = 0);
+
+        $result = $auth->authenticate();
+
+        $this->assertEquals(0, $this->superUserAccessInDb);
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertFalse($result->hasSuperUserAccess());
+    }
+
+    public function test_authenticate_IsSuperUser_IfAccessSynchronizationKeptIt()
+    {
+        $auth = $this->makeAuth($accessSynchronizationLeaves = 1);
+
+        $result = $auth->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS_SUPERUSER_AUTH_CODE, $result->getCode());
+        $this->assertTrue($result->hasSuperUserAccess());
+    }
+
+    /**
+     * @param int $accessSynchronizationLeaves the superuser_access the LDAP attributes map to now
+     */
+    private function makeAuth($accessSynchronizationLeaves)
+    {
+        $this->superUserAccessInDb = 1;
+
+        $auth = new WebServerAuth($this->createMock(LoggerInterface::class));
+
+        $usersModel = $this->getMockBuilder(UserModel::class)
+                           ->onlyMethods(array('getUser', 'generateRandomTokenAuth'))
+                           ->getMock();
+        $usersModel->method('getUser')->willReturnCallback(function () {
+            return array('login' => self::LOGIN, 'superuser_access' => $this->superUserAccessInDb);
+        });
+        $usersModel->method('generateRandomTokenAuth')->willReturn('atoken');
+        $auth->setUsersModel($usersModel);
+
+        $ldapUsers = $this->getMockBuilder(LdapUsers::class)
+                          ->disableOriginalConstructor()
+                          ->onlyMethods(array('getUser'))
+                          ->getMock();
+        $ldapUsers->method('getUser')->willReturn(array('uid' => array(self::LOGIN)));
+        $auth->setLdapUsers($ldapUsers);
+
+        $synchronizer = $this->getMockBuilder(UserSynchronizer::class)
+                             ->onlyMethods(array('synchronizeLdapUser', 'synchronizePiwikAccessFromLdap'))
+                             ->getMock();
+
+        // identity synchronization returns the row as it stands before access is synchronized
+        $synchronizer->method('synchronizeLdapUser')->willReturnCallback(function () use ($usersModel) {
+            return $usersModel->getUser(self::LOGIN);
+        });
+        $synchronizer->method('synchronizePiwikAccessFromLdap')
+                     ->willReturnCallback(function () use ($accessSynchronizationLeaves) {
+                         $this->superUserAccessInDb = $accessSynchronizationLeaves;
+                     });
+        $auth->setUserSynchronizer($synchronizer);
+
+        return $auth;
+    }
+}

--- a/tests/Unit/WebServerAuthLoginResolutionTest.php
+++ b/tests/Unit/WebServerAuthLoginResolutionTest.php
@@ -112,16 +112,21 @@ class WebServerAuthLoginResolutionTest extends TestCase
     }
 
     /**
-     * @param array $existingUser what UserModel::getUser() returns for the asserted login
+     * @param array $existingUser the Matomo user row before this authentication, empty when there is none yet
      */
     private function makeAuth($existingUser)
     {
         $auth = new WebServerAuth($this->createMock(LoggerInterface::class));
 
+        // synchronization creates the user when there is none, so the row is only absent until it runs
+        $userExists = !empty($existingUser);
+
         $usersModel = $this->getMockBuilder(UserModel::class)
                            ->onlyMethods(array('getUser', 'generateRandomTokenAuth'))
                            ->getMock();
-        $usersModel->method('getUser')->willReturn($existingUser);
+        $usersModel->method('getUser')->willReturnCallback(function () use (&$userExists) {
+            return $userExists ? $this->makeUserRow() : array();
+        });
         $usersModel->method('generateRandomTokenAuth')->willReturn('atoken');
         $auth->setUsersModel($usersModel);
 
@@ -135,7 +140,11 @@ class WebServerAuthLoginResolutionTest extends TestCase
         $synchronizer = $this->getMockBuilder(UserSynchronizer::class)
                              ->onlyMethods(array('synchronizeLdapUser', 'synchronizePiwikAccessFromLdap'))
                              ->getMock();
-        $synchronizer->method('synchronizeLdapUser')->willReturn($this->makeUserRow());
+        $synchronizer->method('synchronizeLdapUser')->willReturnCallback(function () use (&$userExists) {
+            $userExists = true;
+
+            return $this->makeUserRow();
+        });
         $auth->setUserSynchronizer($synchronizer);
 
         return $auth;


### PR DESCRIPTION
Refs #AS-730.

### Problem

`Base::synchronizeLdapUser()` caches the user row returned by identity synchronization, then runs access synchronization, and never reads the row back:

```php
$this->userForLogin = $this->userSynchronizer->synchronizeLdapUser($this->login, $ldapUser);
$syncedLogin = !empty($this->userForLogin['login']) ? $this->userForLogin['login'] : $this->login;
$this->userSynchronizer->synchronizePiwikAccessFromLdap($syncedLogin, $ldapUser);
```

`UserSynchronizer::synchronizeLdapUser()` ends with `return $userModel->getUser($syncLogin)`, which is a fresh read but taken before access synchronization. `synchronizePiwikAccessFromLdap()` then clears the user's access and applies what LDAP grants now. `getUserForLogin()` short-circuits on the cached value, so `makeSuccessLogin()` builds the result from the access the row held beforehand rather than the access synchronization just applied.

`Access::reloadAccess()` takes the request's authority from that result, so for one request the two disagree.

### Change

Read the row back after access synchronization, keyed on `$syncedLogin` rather than `$this->login` — `UserMapper::getExpectedLdapUsername()` can append the configured email suffix, so the synchronized login is not always the asserted one.

If the user has been deleted meanwhile the re-read returns empty and `makeSuccessLogin()` throws `User couldn't be found`, which fails the login. That is the safe direction.

### Scope

Not specific to web server auth. `synchronizeLdapUser()` is also reached from `authenticateByLdap()`, which `LdapAuth` and `SynchronizedAuth` both call before `makeSuccessLogin($this->getUserForLogin())`, so all three auth implementations are affected by the one change. The relevant setting is `enable_synchronize_access_from_ldap`, which defaults to `0`; `synchronize_users_after_login` defaults to `1`.

### Tests

`tests/Unit/WebServerAuthAccessSyncTest.php` drives the real `authenticate()` with an access-synchronization stub that changes the flag, and asserts the result reflects the value synchronization left rather than the one read before it, in both directions. I confirmed the first case fails without the change and passes with it.

Plugin unit suite: 155 tests, 357 assertions, OK. PHPCS clean.

### Note

#487 is open against the same file. It touches `getUserForLogin()`, `isSameLogin()` and `makeAuthFailure()`, not `synchronizeLdapUser()`, so the two should merge without conflict. Worth landing #487 first since it is further along.

Longer term the seam is worth closing rather than patching: `Base::synchronizeLdapUser()` assigning `$this->userForLogin` directly is also what let a synchronized row skip the login comparison in #487. Having one synchronization operation return the final post-access row would remove both hazards.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [✔] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [✖] Documentation updated?