### PR TITLE
Port the synchronized access fix to 6.x

### DIFF
--- a/Auth/Base.php
+++ b/Auth/Base.php
@@ -366,6 +366,10 @@ abstract class Base implements Auth
         $syncedLogin = !empty($this->userForLogin['login']) ? $this->userForLogin['login'] : $this->login;
 
         $this->userSynchronizer->synchronizePiwikAccessFromLdap($syncedLogin, $ldapUser);
+
+        // read the row back: access synchronization has just applied the access LDAP grants now, which can
+        // differ from what the row held when it was returned above
+        $this->userForLogin = $this->usersModel->getUser($syncedLogin);
     }
 
     protected function makeSuccessLogin($userInfo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed the loading indicator showing as a white box in dark mode
 * Fixed the login comparison so that logins the database collation treats as equal, but which are different users, are no longer accepted
 * Added termination of a Matomo session when the web server starts authenticating a different user
+* Fixed the login result being built from the user's access as it was before LDAP access synchronization ran
 
 #### LoginLdap 6.0.1 - 2026-09-07
 * Fixed LDAP site access being denied when the instance name or a server separator contains a slash

--- a/tests/Integration/LdapUserSynchronizationTest.php
+++ b/tests/Integration/LdapUserSynchronizationTest.php
@@ -11,6 +11,7 @@
 namespace Piwik\Plugins\LoginLdap\tests\Integration;
 
 use Piwik\Access;
+use Piwik\AuthResult;
 use Piwik\Auth\Password;
 use Piwik\Config;
 use Piwik\Db;
@@ -170,7 +171,11 @@ class LdapUserSynchronizationTest extends LdapIntegrationTest
     {
         $this->enableAccessSynchronization();
 
-        $this->authenticateViaLdap(self::TEST_SUPERUSER_LOGIN, self::TEST_SUPERUSER_PASS);
+        $this->authenticateViaLdap(
+            self::TEST_SUPERUSER_LOGIN,
+            self::TEST_SUPERUSER_PASS,
+            AuthResult::SUCCESS_SUPERUSER_AUTH_CODE
+        );
 
         $superusers = $this->getSuperUsers();
         $this->assertEquals(array(self::TEST_SUPERUSER_LOGIN), $superusers);
@@ -227,7 +232,7 @@ class LdapUserSynchronizationTest extends LdapIntegrationTest
         Config::getInstance()->LoginLdap['instance_name'] = 'myPiwik';
         $this->enableAccessSynchronization();
 
-        $this->authenticateViaLdap('thor', 'bilgesnipe');
+        $this->authenticateViaLdap('thor', 'bilgesnipe', AuthResult::SUCCESS_SUPERUSER_AUTH_CODE);
 
         $superusers = $this->getSuperUsers();
         $this->assertEquals(array('thor'), $superusers);
@@ -256,7 +261,7 @@ class LdapUserSynchronizationTest extends LdapIntegrationTest
         $this->setPiwikInstanceUrl('http://localhost/');
         $this->enableAccessSynchronization();
 
-        $this->authenticateViaLdap('thor', 'bilgesnipe');
+        $this->authenticateViaLdap('thor', 'bilgesnipe', AuthResult::SUCCESS_SUPERUSER_AUTH_CODE);
 
         $superusers = $this->getSuperUsers();
         $this->assertEquals(array('thor'), $superusers);
@@ -320,14 +325,23 @@ class LdapUserSynchronizationTest extends LdapIntegrationTest
         return $result;
     }
 
-    private function authenticateViaLdap($login = self::TEST_LOGIN, $pass = self::TEST_PASS)
-    {
+    /**
+     * @param string $login
+     * @param string $pass
+     * @param int $expectedCode the result code for the access synchronization leaves the user with, which is
+     *                          the superuser code when the LDAP entry grants superuser access
+     */
+    private function authenticateViaLdap(
+        $login = self::TEST_LOGIN,
+        $pass = self::TEST_PASS,
+        $expectedCode = AuthResult::SUCCESS
+    ) {
         $ldapAuth = LdapAuth::makeConfigured();
         $ldapAuth->setLogin($login);
         $ldapAuth->setPassword($pass);
         $authResult = $ldapAuth->authenticate();
 
-        $this->assertEquals(1, $authResult->getCode());
+        $this->assertEquals($expectedCode, $authResult->getCode());
 
         return $authResult;
     }

--- a/tests/Unit/WebServerAuthAccessSyncTest.php
+++ b/tests/Unit/WebServerAuthAccessSyncTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\LoginLdap\tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\AuthResult;
+use Piwik\Config;
+use Piwik\Log\LoggerInterface;
+use Piwik\Plugins\LoginLdap\Auth\WebServerAuth;
+use Piwik\Plugins\LoginLdap\LdapInterop\UserSynchronizer;
+use Piwik\Plugins\LoginLdap\Model\LdapUsers;
+use Piwik\Plugins\UsersManager\Model as UserModel;
+
+/**
+ * @group LoginLdap
+ * @group LoginLdap_Unit
+ * @group LoginLdap_WebServerAuthAccessSyncTest
+ */
+class WebServerAuthAccessSyncTest extends TestCase
+{
+    private const LOGIN = 'ironman';
+
+    /**
+     * The user's superuser_access column, as access synchronization leaves it.
+     *
+     * @var int
+     */
+    private $superUserAccessInDb = 1;
+
+    /**
+     * @var array
+     */
+    private $configBackup;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configBackup = Config::getInstance()->LoginLdap;
+        Config::getInstance()->LoginLdap = array(
+            'use_webserver_auth' => 1,
+            'strip_domain_from_web_auth' => 0,
+        );
+
+        $_SERVER['REMOTE_USER'] = self::LOGIN;
+    }
+
+    public function tearDown(): void
+    {
+        unset($_SERVER['REMOTE_USER']);
+        Config::getInstance()->LoginLdap = $this->configBackup;
+
+        parent::tearDown();
+    }
+
+    /**
+     * Access synchronization runs after the user row has been read, so the result has to be built from the
+     * row as synchronization left it rather than the one read before it.
+     */
+    public function test_authenticate_IsNotSuperUser_IfAccessSynchronizationJustRevokedIt()
+    {
+        $auth = $this->makeAuth($accessSynchronizationLeaves = 0);
+
+        $result = $auth->authenticate();
+
+        $this->assertEquals(0, $this->superUserAccessInDb);
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+        $this->assertFalse($result->hasSuperUserAccess());
+    }
+
+    public function test_authenticate_IsSuperUser_IfAccessSynchronizationKeptIt()
+    {
+        $auth = $this->makeAuth($accessSynchronizationLeaves = 1);
+
+        $result = $auth->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS_SUPERUSER_AUTH_CODE, $result->getCode());
+        $this->assertTrue($result->hasSuperUserAccess());
+    }
+
+    /**
+     * @param int $accessSynchronizationLeaves the superuser_access the LDAP attributes map to now
+     */
+    private function makeAuth($accessSynchronizationLeaves)
+    {
+        $this->superUserAccessInDb = 1;
+
+        $auth = new WebServerAuth($this->createMock(LoggerInterface::class));
+
+        $usersModel = $this->getMockBuilder(UserModel::class)
+                           ->onlyMethods(array('getUser', 'generateRandomTokenAuth'))
+                           ->getMock();
+        $usersModel->method('getUser')->willReturnCallback(function () {
+            return array('login' => self::LOGIN, 'superuser_access' => $this->superUserAccessInDb);
+        });
+        $usersModel->method('generateRandomTokenAuth')->willReturn('atoken');
+        $auth->setUsersModel($usersModel);
+
+        $ldapUsers = $this->getMockBuilder(LdapUsers::class)
+                          ->disableOriginalConstructor()
+                          ->onlyMethods(array('getUser'))
+                          ->getMock();
+        $ldapUsers->method('getUser')->willReturn(array('uid' => array(self::LOGIN)));
+        $auth->setLdapUsers($ldapUsers);
+
+        $synchronizer = $this->getMockBuilder(UserSynchronizer::class)
+                             ->onlyMethods(array('synchronizeLdapUser', 'synchronizePiwikAccessFromLdap'))
+                             ->getMock();
+
+        // identity synchronization returns the row as it stands before access is synchronized
+        $synchronizer->method('synchronizeLdapUser')->willReturnCallback(function () use ($usersModel) {
+            return $usersModel->getUser(self::LOGIN);
+        });
+        $synchronizer->method('synchronizePiwikAccessFromLdap')
+                     ->willReturnCallback(function () use ($accessSynchronizationLeaves) {
+                         $this->superUserAccessInDb = $accessSynchronizationLeaves;
+                     });
+        $auth->setUserSynchronizer($synchronizer);
+
+        return $auth;
+    }
+}


### PR DESCRIPTION
Ports #488 to 6.x-dev. Refs #AS-730.

Cherry-pick of `8daf687` and `cef36f9`.

### Change

`Base::synchronizeLdapUser()` cached the user row returned by identity synchronization, ran access synchronization, and never read the row back, so `makeSuccessLogin()` built the result from the access the row held beforehand rather than the access synchronization had just applied. It now reads the row back, keyed on `$syncedLogin` — `UserMapper::getExpectedLdapUsername()` can append the configured email suffix, so the synchronized login is not always the asserted one.

Not specific to web server auth: `synchronizeLdapUser()` is also reached from `authenticateByLdap()`, which `LdapAuth` and `SynchronizedAuth` both call, so the one change covers all three implementations.

`LdapUserSynchronizationTest::authenticateViaLdap()` asserted the plain success code for every caller, including three whose LDAP entry grants superuser access. Those authentications now report the access synchronization leaves the user with, so the helper takes an expected code.

### Differences from the 5.x commits

The changelog line folds into the untagged **6.0.2** section with the `*` bullets 6.x uses.

`f3214e5`, the third commit on #488, is deliberately **not** included. It adapts `tests/Unit/WebServerAuthLoginResolutionTest.php`, which does not exist on 6.x-dev — that file arrives with #484, and I have added the adapted version there instead.

### Interaction with #484

#484 is still open and also targets 6.0.2, so the two conflict on `CHANGELOG.md` only; whichever merges second needs a one-line union of the 6.0.2 bullets. There is no code conflict.

I merged both branches onto 6.x-dev locally to check the combination rather than wait for CI to find out: only that changelog conflict, and with it resolved the suite is 198 tests, 431 assertions, OK with PHPStan clean.

### Verification

On this branch alone:

- `plugins/LoginLdap/tests/Unit` — 151 tests, 325 assertions, OK
- PHPStan level 5 — no errors
- PHPCS `Matomo` standard — no errors

The integration tests need the LDAP fixture and the local core is Matomo 5.14.0-alpha rather than Matomo 6, so CI is the real check.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [✔] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [✖] Documentation updated?